### PR TITLE
Add key validation for CanonicalizedMap.[]= to prevent to affect its keys and values

### DIFF
--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -64,6 +64,7 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
   }
 
   void operator []=(K key, V value) {
+    if (!_isValidKey(key)) return;
     _base[_canonicalize(key)] = new Pair(key, value);
   }
 

--- a/test/canonicalized_map_test.dart
+++ b/test/canonicalized_map_test.dart
@@ -22,6 +22,15 @@ void main() {
       expect(map["foo"], isNull);
     });
 
+    test("set affects nothing for uncanonicalizable key", () {
+      expect(() {
+        map["foo"] = "value";
+      }, returnsNormally);
+      expect(map["foo"], isNull);
+      expect(map.containsKey("foo"), isFalse);
+      expect(map.length, equals(0));
+    });
+
     test("canonicalizes keys for addAll", () {
       map.addAll({
         "1": "value 1",


### PR DESCRIPTION
Hello.
I often use this nice package for my projects. I found a unexpected behavior that seems to be a specification bug, so I decided to suggest this fix.

The current `CanonicalizedMap.[]=` doesn't validate keys with `isValidKey` function. `CanonicalizedMap.[]` validates keys so that map[invalidKey] always returns null, but `CanonicalizedMap.[]=` affects other external behavior like `keys` and `length`.

```dart
var map = new CanonicalizedMap<int, int, String>(
    (int n) => n % 10, isValidKey: (int n) => n >= 0);
map[-1] = "value"; // current: return normally, suggestion: return normally
print(map[-1]); // current: null, suggestion: null

print(map.length); // current: 1, suggestion: 0
print(map.keys); // current: (-1), suggestion: ()
print(map); // current: "{-1: value}", suggestion: "{}"
```

If you accept this suggestion, you might think `CanonicalizedMap.[]` and `CanonicalizedMap.remove` no longer need to validate keys. But the `canonicalize` function sometimes throws an exception for invalid key (e.g. `int.parse("foo")` throws `FormatException`), so they still need to validate key.

I hope you like it.