### PR TITLE
adding a const .empty() constructor to UnmodifiableSetView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 packages
 .packages
 pubspec.lock
+*.iml

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -5,6 +5,7 @@
 export "dart:collection" show UnmodifiableListView, UnmodifiableMapView;
 
 import 'wrappers.dart';
+import 'dart:collection' show IterableBase;
 
 /// A fixed-length list.
 ///
@@ -91,9 +92,110 @@ abstract class NonGrowableListMixin<E> implements List<E> {
 /// such as [add] and [remove], throw an [UnsupportedError].
 /// Permitted operations defer to the wrapped set.
 class UnmodifiableSetView<E> extends DelegatingSet<E>
-                             with UnmodifiableSetMixin<E> {
+    with UnmodifiableSetMixin<E> {
   UnmodifiableSetView(Set<E> setBase) : super(setBase);
+
+  /// Constant constructor cannot be declared for a class with a mixin!!!!!
+  const UnmodifiableSetView.empty() : this( const _EmptyUnmodifiableSet());
 }
+
+// A super class with const constructor is needed, so IterableBase<E> fits.
+class _EmptyUnmodifiableSet<E> extends IterableBase<E> implements Set<E> {
+  static /*=T*/ _throw/*<T>*/() {
+    throw new UnsupportedError("Cannot add to an unmodifiable empty Set");
+  }
+
+  /// Returns an empty Iterator.
+  // new Iterabel.generate(0).iterator reduces to
+  // new EmptyIterable().iterator so this should be efficient.
+  Iterator<E> get _emptyIterator => new Iterable<E>.generate(0).iterator;
+
+  /// Returns always an empty Iterator;
+  @override
+  Iterator<E> get iterator => _emptyIterator;
+
+  /// Returns always 0;
+  /// The length of en empty Set fixed to 0.
+  @override
+  int get length => 0;
+
+  const _EmptyUnmodifiableSet();
+
+  /// Throws an [UnsupportedError];
+  /// operations that add to the set are disallowed.
+  @override
+  bool add(E value) => _throw();
+
+  /// Throws an [UnsupportedError];
+  /// operations that add to the set are disallowed.
+  @override
+  void addAll(Iterable<E> elements) => _throw();
+
+  /// Does nothing;
+  /// clear on an empty set results in an empty set.
+  @override
+  void clear() {}
+
+  /// Returns always false;
+  /// The empty set doesn't contain any elements.
+  @override
+  bool contains(Object element) => false;
+
+  /// Returns always null;
+  /// The empty set doesn't contain any elements and therefore returns null.
+  @override
+  E lookup(Object element) => null;
+
+  /// Returns always false;
+  /// The empty set doesn't contain any elements and therefore can't remove one.
+  @override
+  bool remove(Object element) => false;
+
+  /// Does nothing.
+  /// The empty set doesn't contain any elements and therefore can't remove one.
+  @override
+  void removeAll(Iterable<Object> elements) {}
+
+  /// Does nothing.
+  /// The empty set doesn't contain any elements and therefore can't remove one.
+  @override
+  void removeWhere(bool test(E element)) {}
+
+  /// Does nothing.
+  /// The empty set doesn't contain any elements and therefore can't remove one.
+  @override
+  void retainWhere(bool test(E element)) {}
+
+  /// Doesn't do anything;
+  /// An optional remove on an empty set changes nothing.
+  @override
+  void retainAll(Iterable<Object> elements){}
+
+  /// Returns itself because the behaviour (in regards to add(), remove())
+  /// of the returning Set<E> should be the same.
+  @override
+  Set<E> toSet() => this;
+
+  /// Returns a copy of other;
+  /// union with an empty set leads to a copy.
+  @override
+  Set<E> union(Set<E> other) => new Set.from(other);
+
+  /// Returns an empty set;
+  /// there are no elements in this (empty) set that are also in other.
+  @override
+  Set<E> intersection(Set<Object> other) => new Set();
+
+  /// Returns an empty set;
+  /// there are no elements in this (empty) set that aren't in other.
+  @override
+  Set<E> difference(Set<Object> other) => new Set();
+
+  /// Returns true if other is empty, else false:
+  @override
+  bool containsAll(Iterable<Object> other) => other.isEmpty;
+}
+
 
 /// Mixin class that implements a throwing version of all set operations that
 /// change the Set.

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export "dart:collection" show UnmodifiableListView, UnmodifiableMapView;
+import 'dart:collection' show IterableBase;
 
 import 'wrappers.dart';
-import 'dart:collection' show IterableBase;
+
+export "dart:collection" show UnmodifiableListView, UnmodifiableMapView;
 
 /// A fixed-length list.
 ///
@@ -95,12 +96,16 @@ class UnmodifiableSetView<E> extends DelegatingSet<E>
     with UnmodifiableSetMixin<E> {
   UnmodifiableSetView(Set<E> setBase) : super(setBase);
 
-  /// Constant constructor cannot be declared for a class with a mixin!!!!!
-  const UnmodifiableSetView.empty() : this( const _EmptyUnmodifiableSet());
+  /// Returns an unmodifiable empty set.
+  const factory UnmodifiableSetView.empty() = _EmptyUnmodifiableSet<E>;
 }
 
+/// An unmodifiable empty set that doesn't allow adding-operations.
+/// Removing-operations are ok, because the don't modify the contents of an
+/// empty set.
 // A super class with const constructor is needed, so IterableBase<E> fits.
-class _EmptyUnmodifiableSet<E> extends IterableBase<E> implements Set<E> {
+class _EmptyUnmodifiableSet<E> extends IterableBase<E>
+    implements UnmodifiableSetView<E> {
   static /*=T*/ _throw/*<T>*/() {
     throw new UnsupportedError("Cannot add to an unmodifiable empty Set");
   }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -107,7 +107,8 @@ class UnmodifiableSetView<E> extends DelegatingSet<E>
 class _EmptyUnmodifiableSet<E> extends IterableBase<E>
     implements UnmodifiableSetView<E> {
   static /*=T*/ _throw/*<T>*/() {
-    throw new UnsupportedError("Cannot add to an unmodifiable empty Set");
+    throw new UnsupportedError(
+        "Cannot call modifying operations on an unmodifiable Set");
   }
 
   /// Returns an empty Iterator.
@@ -127,7 +128,7 @@ class _EmptyUnmodifiableSet<E> extends IterableBase<E>
   const _EmptyUnmodifiableSet();
 
   /// Throws an [UnsupportedError];
-  /// operations that add to the set are disallowed.
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
   bool add(E value) => _throw();
 
@@ -136,45 +137,49 @@ class _EmptyUnmodifiableSet<E> extends IterableBase<E>
   @override
   void addAll(Iterable<E> elements) => _throw();
 
-  /// Does nothing;
-  /// clear on an empty set results in an empty set.
+  /// Throws an [UnsupportedError];
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
-  void clear() {}
+  void clear() => _throw();
 
   /// Returns always false;
   /// The empty set doesn't contain any elements.
   @override
   bool contains(Object element) => false;
 
+  /// Returns true if other is empty, else false:
+  @override
+  bool containsAll(Iterable<Object> other) => other.isEmpty;
+
   /// Returns always null;
   /// The empty set doesn't contain any elements and therefore returns null.
   @override
   E lookup(Object element) => null;
 
-  /// Returns always false;
-  /// The empty set doesn't contain any elements and therefore can't remove one.
+  /// Throws an [UnsupportedError];
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
-  bool remove(Object element) => false;
+  bool remove(Object element) => _throw();
 
-  /// Does nothing.
-  /// The empty set doesn't contain any elements and therefore can't remove one.
+  /// Throws an [UnsupportedError];
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
-  void removeAll(Iterable<Object> elements) {}
+  void removeAll(Iterable<Object> elements) => _throw();
 
-  /// Does nothing.
-  /// The empty set doesn't contain any elements and therefore can't remove one.
+  /// Throws an [UnsupportedError];
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
-  void removeWhere(bool test(E element)) {}
+  void removeWhere(bool test(E element)) => _throw();
 
-  /// Does nothing.
-  /// The empty set doesn't contain any elements and therefore can't remove one.
+  /// Throws an [UnsupportedError];
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
-  void retainWhere(bool test(E element)) {}
+  void retainWhere(bool test(E element)) => _throw();
 
-  /// Doesn't do anything;
-  /// An optional remove on an empty set changes nothing.
+  /// Throws an [UnsupportedError];
+  /// modifying operations are disallowed on unmodifiable sets.
   @override
-  void retainAll(Iterable<Object> elements){}
+  void retainAll(Iterable<Object> elements) => _throw();
 
   /// Returns itself because the behaviour (in regards to add(), remove())
   /// of the returning Set<E> should be the same.
@@ -195,10 +200,6 @@ class _EmptyUnmodifiableSet<E> extends IterableBase<E>
   /// there are no elements in this (empty) set that aren't in other.
   @override
   Set<E> difference(Set<Object> other) => new Set();
-
-  /// Returns true if other is empty, else false:
-  @override
-  bool containsAll(Iterable<Object> other) => other.isEmpty;
 }
 
 

--- a/test/unmodifiable_collection_test.dart
+++ b/test/unmodifiable_collection_test.dart
@@ -35,6 +35,8 @@ main() {
 
   Set aSet = new Set();
   testUnmodifiableSet(aSet, new UnmodifiableSetView(aSet), "empty");
+  aSet = new Set();
+  testUnmodifiableSet(aSet, const UnmodifiableSetView.empty(), "const empty");
   aSet = new Set.from([42]);
   testUnmodifiableSet(aSet, new UnmodifiableSetView(aSet), "single-42");
   aSet = new Set.from([7]);


### PR DESCRIPTION
as discussed in [this issue](https://github.com/dart-lang/collection/issues/20) i added a const constructor to `UnmodifiableSetView` to create an unmodifiable, empty set (for e.g. a default optional methodparameter that expects a set; similar to `const []` and `const {}` if one requires a const empty list/map).
```
class UnmodifiableSetView<E> extends DelegatingSet<E> with UnmodifiableSetMixin<E> {
  UnmodifiableSetView(Set<E> setBase) : super(setBase);
  const factory UnmodifiableSetView.empty() = _EmptyUnmodifiableSet<E>;
}
```