### PR TITLE
Fix case-insensitivity bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.12.1
+
+* Fix a missing import.
+
+* Fix `equalsIgnoreAsciiCase()`, which previously was not actually
+  case-insensitive.
+
 ## 1.12.0
 
 * Add `CaseInsensitiveEquality`.

--- a/lib/src/comparators.dart
+++ b/lib/src/comparators.dart
@@ -32,10 +32,10 @@ bool equalsIgnoreAsciiCase(String a, String b) {
     if (aChar == bChar) continue;
     // Quick-check for whether this may be different cases of the same letter.
     if (aChar ^ bChar != _asciiCaseBit) return false;
-    // If it's possible, then check if either character is actually an ASCII
-    // letter.
-    int aCharUpperCase = aChar | _asciiCaseBit;
-    if (_upperCaseA <= aCharUpperCase && aCharUpperCase <= _upperCaseZ) {
+    // If it's possible, then check if one of the characters is actually an
+    // ASCII letter.
+    int aCharLowerCase = aChar | _asciiCaseBit;
+    if (_lowerCaseA <= aCharLowerCase && aCharLowerCase <= _lowerCaseZ) {
       continue;
     }
     return false;

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -4,6 +4,8 @@
 
 import "dart:collection";
 
+import "comparators.dart";
+
 const int _HASH_MASK = 0x7fffffff;
 
 /// A generic equality relation on objects.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.12.0
+version: 1.12.1
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
The previous release was missing an import, and equalsIgnoreAsciiCase()
didn't work at all.