### PR TITLE
Release 1.12.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-## 1.12.1
-
-* Fix bug in `equalsIgnoreAsciiCase`.
-
 ## 1.12.0
 
 * Add `CaseInsensitiveEquality`.
+
+* Fix bug in `equalsIgnoreAsciiCase`.
 
 ## 1.11.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.12.1
+version: 1.12.0
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
It turns out I hadn't released this yet, so there's no need for a
1.12.1 release.