### PR TITLE
Remove strong-mode and deprecation warnings

### DIFF
--- a/test/algorithms_test.dart
+++ b/test/algorithms_test.dart
@@ -78,7 +78,7 @@ void main() {
   });
 
   test("binsearchCompare0", () {
-    expect(binarySearch([], new C(2), compare: compareC), equals(-1));
+    expect(binarySearch(<C>[], new C(2), compare: compareC), equals(-1));
   });
 
   test("binsearchCompare1", () {
@@ -125,7 +125,7 @@ void main() {
   });
 
   test("lowerboundCompare0", () {
-    expect(lowerBound([], new C(2), compare: compareC), equals(0));
+    expect(lowerBound(<C>[], new C(2), compare: compareC), equals(0));
   });
 
   test("lowerboundCompare1", () {

--- a/test/equality_test.dart
+++ b/test/equality_test.dart
@@ -114,8 +114,8 @@ main() {
   var map2b = {"x": [o(6), o(5), o(4)], "y": [null, false, true]};
   var l1 = [map1a, map1b];
   var l2 = [map2a, map2b];
-  var s1 = new Set.from(l1);
-  var s2 = new Set.from([map2b, map2a]);
+  var s1 = new Set<Map>.from(l1);
+  var s2 = new Set<Map>.from([map2b, map2a]);
 
   test("RecursiveEquality", () {
     const unordered = const UnorderedIterableEquality();
@@ -136,7 +136,7 @@ main() {
     const listmapval = const ListEquality(mapval);
     expect(listmapval.equals(l1, l2),
         isTrue);
-    const setmapval = const SetEquality(mapval);
+    const setmapval = const SetEquality<Map>(mapval);
     expect(setmapval.equals(s1, s2),
         isTrue);
   });

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -11,8 +11,8 @@ void main() {
     test("with an empty map returns an empty map", () {
       expect(
           mapMap({},
-              key: expectAsync((_, __) {}, count: 0),
-              value: expectAsync((_, __) {}, count: 0)),
+              key: expectAsync2((_, __) {}, count: 0),
+              value: expectAsync2((_, __) {}, count: 0)),
           isEmpty);
     });
 
@@ -47,7 +47,7 @@ void main() {
 
   group("mergeMaps()", () {
     test("with empty maps returns an empty map", () {
-      expect(mergeMaps({}, {}, value: expectAsync((_, __) {}, count: 0)),
+      expect(mergeMaps({}, {}, value: expectAsync2((_, __) {}, count: 0)),
           isEmpty);
     });
 
@@ -70,7 +70,7 @@ void main() {
 
   group("groupBy()", () {
     test("returns an empty map for an empty iterable", () {
-      expect(groupBy([], expectAsync((_) {}, count: 0)), isEmpty);
+      expect(groupBy([], expectAsync1((_) {}, count: 0)), isEmpty);
     });
 
     test("groups elements by the function's return value", () {
@@ -83,8 +83,8 @@ void main() {
   group("minBy()", () {
     test("returns null for an empty iterable", () {
       expect(
-          minBy([], expectAsync((_) {}, count: 0),
-              compare: expectAsync((_, __) {}, count: 0)),
+          minBy([], expectAsync1((_) {}, count: 0),
+              compare: expectAsync2((_, __) {}, count: 0)),
           isNull);
     });
 
@@ -110,8 +110,8 @@ void main() {
   group("maxBy()", () {
     test("returns null for an empty iterable", () {
       expect(
-          maxBy([], expectAsync((_) {}, count: 0),
-              compare: expectAsync((_, __) {}, count: 0)),
+          maxBy([], expectAsync1((_) {}, count: 0),
+              compare: expectAsync2((_, __) {}, count: 0)),
           isNull);
     });
 

--- a/test/typed_wrapper/iterable_test.dart
+++ b/test/typed_wrapper/iterable_test.dart
@@ -72,7 +72,7 @@ void main() {
       wrapper.forEach(results.add);
       expect(results, equals([1, 2, 3, 4, 5]));
 
-      emptyWrapper.forEach(expectAsync((_) {}, count: 0));
+      emptyWrapper.forEach(expectAsync1((_) {}, count: 0));
     });
 
     test("isEmpty", () {
@@ -204,7 +204,7 @@ void main() {
 
     group("throws a CastError for", () {
       test("any()", () {
-        expect(() => wrapper.any(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.any(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
@@ -213,12 +213,12 @@ void main() {
       });
 
       test("every()", () {
-        expect(() => wrapper.every(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.every(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
       test("expand()", () {
-        var lazy = wrapper.expand(expectAsync((_) => [], count: 0));
+        var lazy = wrapper.expand(expectAsync1((_) => [], count: 0));
         expect(() => lazy.first, throwsCastError);
       });
 
@@ -227,17 +227,17 @@ void main() {
       });
 
       test("firstWhere()", () {
-        expect(() => wrapper.firstWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.firstWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
       test("fold()", () {
-        expect(() => wrapper.fold(null, expectAsync((_, __) => null, count: 0)),
+        expect(() => wrapper.fold(null, expectAsync2((_, __) => null, count: 0)),
             throwsCastError);
       });
 
       test("forEach()", () {
-        expect(() => wrapper.forEach(expectAsync((_) {}, count: 0)),
+        expect(() => wrapper.forEach(expectAsync1((_) {}, count: 0)),
             throwsCastError);
       });
 
@@ -252,17 +252,17 @@ void main() {
       });
 
       test("lastWhere()", () {
-        expect(() => wrapper.lastWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.lastWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
       test("map()", () {
-        var lazy = wrapper.map(expectAsync((_) => null, count: 0));
+        var lazy = wrapper.map(expectAsync1((_) => null, count: 0));
         expect(() => lazy.first, throwsCastError);
       });
 
       test("reduce()", () {
-        expect(() => wrapper.reduce(expectAsync((_, __) => null, count: 0)),
+        expect(() => wrapper.reduce(expectAsync2((_, __) => null, count: 0)),
             throwsCastError);
       });
 
@@ -272,7 +272,7 @@ void main() {
 
       test("singleWhere()", () {
         expect(() {
-          singleWrapper.singleWhere(expectAsync((_) => false, count: 0));
+          singleWrapper.singleWhere(expectAsync1((_) => false, count: 0));
         }, throwsCastError);
       });
 
@@ -282,7 +282,7 @@ void main() {
       });
 
       test("skipWhile()", () {
-        var lazy = wrapper.skipWhile(expectAsync((_) => false, count: 0));
+        var lazy = wrapper.skipWhile(expectAsync1((_) => false, count: 0));
         expect(() => lazy.first, throwsCastError);
       });
 
@@ -292,7 +292,7 @@ void main() {
       });
 
       test("takeWhile()", () {
-        var lazy = wrapper.takeWhile(expectAsync((_) => false, count: 0));
+        var lazy = wrapper.takeWhile(expectAsync1((_) => false, count: 0));
         expect(() => lazy.first, throwsCastError);
       });
 
@@ -307,7 +307,7 @@ void main() {
       });
 
       test("where()", () {
-        var lazy = wrapper.where(expectAsync((_) => false, count: 0));
+        var lazy = wrapper.where(expectAsync1((_) => false, count: 0));
         expect(() => lazy.first, throwsCastError);
       });
     });

--- a/test/typed_wrapper/list_test.dart
+++ b/test/typed_wrapper/list_test.dart
@@ -253,12 +253,12 @@ void main() {
       });
 
       test("removeWhere()", () {
-        expect(() => wrapper.removeWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.removeWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
       test("retainWhere()", () {
-        expect(() => wrapper.retainWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.retainWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
@@ -268,7 +268,7 @@ void main() {
       });
 
       test("sort()", () {
-        expect(() => wrapper.sort(expectAsync((_, __) => 0, count: 0)),
+        expect(() => wrapper.sort(expectAsync2((_, __) => 0, count: 0)),
             throwsCastError);
       });
 

--- a/test/typed_wrapper/map_test.dart
+++ b/test/typed_wrapper/map_test.dart
@@ -62,7 +62,7 @@ void main() {
       expect(results,
           unorderedEquals([["foo", 1], ["bar", 2], ["baz", 3], ["bang", 4]]));
 
-      emptyWrapper.forEach(expectAsync((_, __) {}, count: 0));
+      emptyWrapper.forEach(expectAsync2((_, __) {}, count: 0));
     });
 
     test("isEmpty", () {
@@ -86,7 +86,7 @@ void main() {
     });
 
     test("putIfAbsent()", () {
-      expect(wrapper.putIfAbsent("foo", expectAsync(() => null, count: 0)),
+      expect(wrapper.putIfAbsent("foo", expectAsync1((_) => null, count: 0)),
           equals(1));
 
       expect(wrapper.putIfAbsent("qux", () => 6), equals(6));
@@ -129,7 +129,7 @@ void main() {
 
     group("throws a CastError for", () {
       test("forEach()", () {
-        expect(() => wrapper.forEach(expectAsync((_, __) {}, count: 0)),
+        expect(() => wrapper.forEach(expectAsync2((_, __) {}, count: 0)),
             throwsCastError);
       });
 
@@ -225,7 +225,7 @@ void main() {
 
     group("throws a CastError for", () {
       test("forEach()", () {
-        expect(() => wrapper.forEach(expectAsync((_, __) {}, count: 0)),
+        expect(() => wrapper.forEach(expectAsync2((_, __) {}, count: 0)),
             throwsCastError);
       });
 

--- a/test/typed_wrapper/queue_test.dart
+++ b/test/typed_wrapper/queue_test.dart
@@ -98,12 +98,12 @@ void main() {
       });
 
       test("removeWhere()", () {
-        expect(() => wrapper.removeWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.removeWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
       test("retainWhere()", () {
-        expect(() => wrapper.retainWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.retainWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
     });

--- a/test/typed_wrapper/set_test.dart
+++ b/test/typed_wrapper/set_test.dart
@@ -111,12 +111,12 @@ void main() {
       });
 
       test("removeWhere()", () {
-        expect(() => wrapper.removeWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.removeWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 
       test("retainWhere()", () {
-        expect(() => wrapper.retainWhere(expectAsync((_) => false, count: 0)),
+        expect(() => wrapper.retainWhere(expectAsync1((_) => false, count: 0)),
             throwsCastError);
       });
 

--- a/test/union_set_test.dart
+++ b/test/union_set_test.dart
@@ -35,7 +35,7 @@ void main() {
     });
 
     test("map() doesn't run on any elements", () {
-      expect(set.map(expectAsync((_) {}, count: 0)), isEmpty);
+      expect(set.map(expectAsync1((_) {}, count: 0)), isEmpty);
     });
   });
 


### PR DESCRIPTION
Required a bit of help where inference couldn't do it and fixing `expectAsync`.