### PR TITLE
Export classes from dart:collection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 ## 1.15.0
 
-* Re-export a number of platform library classes from `dart:collection`
-  in anticipation of moving the classes to this package for Dart 2.0.
+* Re-export the following platform library classes from `dart:collection`
+  in anticipation of moving the classes to this package for Dart 2.0:
+  * `DoubleLinkedQueue`
+  * `DoubleLinkedQueueEntry`
+  * `HasNextIterator`
+  * `LinkedList`
+  * `LinkedListEntry`
+  * `MapView`
+  * `SplayTreeMap`
+  * `SplayTreeSet`
+  * `UnmodifiableListView`
+  * `UnmodifiableMapBase`
+  * `UnmodifiableMapView`
 
 ## 1.14.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.15.0
+
+* Re-export a number of platform library classes from `dart:collection`
+  in anticipation of moving the classes to this package for Dart 2.0.
+
 ## 1.14.1
 
 * Make `Equality` implementations accept `null` as argument to `hash`.
@@ -10,7 +15,7 @@
 
 ## 1.13.0
 
-* Add `EqualityBy`
+* Add `EqualityBy`.
 
 ## 1.12.0
 

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -2,6 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// TODO(lrn): Move the classes to this package.
+export "dart:collection" show
+    DoubleLinkedQueue,
+    DoubleLinkedQueueEntry,
+    HasNextIterator,
+    LinkedList,
+    LinkedListEntry,
+    MapView, // TODO(lrn): Drop this class, it is equivalent to DelegatingMap.
+    SplayTreeMap,
+    SplayTreeSet,
+    UnmodifiableListView,
+    UnmodifiableMapBase,
+    UnmodifiableMapView;
+
 export "src/algorithms.dart";
 export "src/canonicalized_map.dart";
 export "src/combined_wrappers/combined_iterable.dart";

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -3,18 +3,19 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // TODO(lrn): Move the classes to this package.
-export "dart:collection" show
-    DoubleLinkedQueue,
-    DoubleLinkedQueueEntry,
-    HasNextIterator,
-    LinkedList,
-    LinkedListEntry,
-    MapView, // TODO(lrn): Drop this class, it is equivalent to DelegatingMap.
-    SplayTreeMap,
-    SplayTreeSet,
-    UnmodifiableListView,
-    UnmodifiableMapBase,
-    UnmodifiableMapView;
+export "dart:collection"
+    show
+        DoubleLinkedQueue,
+        DoubleLinkedQueueEntry,
+        HasNextIterator,
+        LinkedList,
+        LinkedListEntry,
+        MapView, // TODO(lrn): Drop this class, it is equivalent to DelegatingMap.
+        SplayTreeMap,
+        SplayTreeSet,
+        UnmodifiableListView,
+        UnmodifiableMapBase,
+        UnmodifiableMapView;
 
 export "src/algorithms.dart";
 export "src/canonicalized_map.dart";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.14.4-dev
+version: 1.15.0
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
In preparation of moving the classes to this package in Dart 2.0.