### PR TITLE
Add methods where needed for Dart 2.0 core lib changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.14.4
+
+* Add implementation stubs of upcoming Dart 2.0 core library methods, namely
+  new methods for classes that implement Iterable, List, Map, Queue, and Set.
+
+## 1.14.3
+
+* Fix MapKeySet.lookup to be a valid override in strong mode.
+
+## 1.14.2
+
+* Add type arguments to SyntheticInvocation.
+
 ## 1.14.1
 
 * Make `Equality` implementations accept `null` as argument to `hash`.

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -69,6 +69,22 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
     other.forEach((key, value) => this[key] = value);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('addEntries');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _base.clear();
   }
@@ -80,6 +96,15 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
 
   bool containsValue(Object value) =>
       _base.values.any((pair) => pair.last == value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('entries');
+  }
 
   void forEach(void f(K key, V value)) {
     _base.forEach((key, pair) => f(pair.first, pair.last));
@@ -93,6 +118,15 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
 
   int get length => _base.length;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('map');
+  }
+
   V putIfAbsent(K key, V ifAbsent()) {
     return _base
         .putIfAbsent(_canonicalize(key), () => new Pair(key, ifAbsent()))
@@ -103,6 +137,34 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
     if (!_isValidKey(key)) return null;
     var pair = _base.remove(_canonicalize(key as K));
     return pair == null ? null : pair.last;
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError('removeWhere');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError('retype');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError('update');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError('updateAll');
   }
 
   Iterable<V> get values => _base.values.map((pair) => pair.last);

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -69,18 +69,14 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
     other.forEach((key, value) => this[key] = value);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void addEntries(Iterable<Object> entries) {
     // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
     throw new UnimplementedError('addEntries');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
     throw new UnimplementedError('cast');
   }
@@ -97,9 +93,7 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
   bool containsValue(Object value) =>
       _base.values.any((pair) => pair.last == value);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_getter
   Iterable<Null> get entries {
     // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
@@ -118,9 +112,7 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
 
   int get length => _base.length;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
@@ -139,30 +131,22 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
     return pair == null ? null : pair.last;
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void removeWhere(bool test(K key, V value)) {
     throw new UnimplementedError('removeWhere');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> retype<K2, V2>() {
     throw new UnimplementedError('retype');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   V update(K key, V update(V value), {V ifAbsent()}) {
     throw new UnimplementedError('update');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void updateAll(V update(K key, V value)) {
     throw new UnimplementedError('updateAll');
   }

--- a/lib/src/empty_unmodifiable_set.dart
+++ b/lib/src/empty_unmodifiable_set.dart
@@ -20,9 +20,14 @@ class EmptyUnmodifiableSet<E> extends IterableBase<E>
 
   const EmptyUnmodifiableSet();
 
+  EmptyUnmodifiableSet<T> cast<T>() => const EmptyUnmodifiableSet<T>();
   bool contains(Object element) => false;
   bool containsAll(Iterable<Object> other) => other.isEmpty;
+  Iterable<E> followedBy(Iterable<E> other) => new Set.from(other);
   E lookup(Object element) => null;
+  EmptyUnmodifiableSet<T> retype<T>() => const EmptyUnmodifiableSet<T>();
+  E singleWhere(bool test(E element), {E orElse()}) => super.singleWhere(test);
+  Iterable<T> whereType<T>() => const EmptyUnmodifiableSet<T>();
   Set<E> toSet() => new Set();
   Set<E> union(Set<E> other) => new Set.from(other);
   Set<E> intersection(Set<Object> other) => new Set();

--- a/lib/src/queue_list.dart
+++ b/lib/src/queue_list.dart
@@ -80,16 +80,12 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
     }
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   QueueList<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   QueueList<T> retype<T>() {
     throw new UnimplementedError('retype');
   }

--- a/lib/src/queue_list.dart
+++ b/lib/src/queue_list.dart
@@ -80,6 +80,20 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
     }
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  QueueList<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  QueueList<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
+
   String toString() => IterableBase.iterableToFullString(this, "{", "}");
 
   // Queue interface.

--- a/lib/src/typed_wrappers.dart
+++ b/lib/src/typed_wrappers.dart
@@ -21,9 +21,7 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
 
   bool any(bool test(E element)) => _base.any(_validate(test));
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -45,9 +43,7 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
       _base.fold(initialValue,
           (previousValue, element) => combine(previousValue, element as E));
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<E> followedBy(Iterable<E> other) {
     throw new UnimplementedError('followedBy');
   }
@@ -74,9 +70,7 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
   E reduce(E combine(E value, E element)) =>
       _base.reduce((value, element) => combine(value as E, element as E)) as E;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -106,9 +100,7 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
   Iterable<E> where(bool test(E element)) =>
       new TypeSafeIterable<E>(_base.where(_validate(test)));
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
     throw new UnimplementedError('whereType');
   }
@@ -146,9 +138,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase[index] = value;
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<E> operator +(List<E> other) {
     throw new UnimplementedError('+');
   }
@@ -163,9 +153,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
 
   Map<int, E> asMap() => new TypeSafeMap<int, E>(_listBase.asMap());
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -178,9 +166,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase.fillRange(start, end, fillValue);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_setter
   set first(E value) {
     if (this.isEmpty) throw new RangeError.index(0, this);
     this[0] = value;
@@ -191,9 +177,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
 
   int indexOf(E element, [int start = 0]) => _listBase.indexOf(element, start);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   int indexWhere(bool test(E element), [int start = 0]) {
     throw new UnimplementedError('indexWhere');
   }
@@ -206,9 +190,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase.insertAll(index, iterable);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_setter
   set last(E value) {
     if (this.isEmpty) throw new RangeError.index(0, this);
     this[this.length - 1] = value;
@@ -217,9 +199,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
   int lastIndexOf(E element, [int start]) =>
       _listBase.lastIndexOf(element, start);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   int lastIndexWhere(bool test(E element), [int start]) {
     throw new UnimplementedError('lastIndexWhere');
   }
@@ -250,9 +230,7 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase.retainWhere(_validate(test));
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -298,9 +276,7 @@ class TypeSafeSet<E> extends TypeSafeIterable<E> implements DelegatingSet<E> {
     _setBase.addAll(elements);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -337,9 +313,7 @@ class TypeSafeSet<E> extends TypeSafeIterable<E> implements DelegatingSet<E> {
     _setBase.retainWhere(_validate(test));
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -373,9 +347,7 @@ class TypeSafeQueue<E> extends TypeSafeIterable<E>
     _baseQueue.addLast(value);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Queue<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -394,9 +366,7 @@ class TypeSafeQueue<E> extends TypeSafeIterable<E>
     _baseQueue.retainWhere(_validate(test));
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Queue<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -425,18 +395,14 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
     _base.addAll(other);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void addEntries(Iterable<Object> entries) {
     // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
     throw new UnimplementedError('addEntries');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
     throw new UnimplementedError('cast');
   }
@@ -449,9 +415,7 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
 
   bool containsValue(Object value) => _base.containsValue(value);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_getter
   Iterable<Null> get entries {
     // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
@@ -470,9 +434,7 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
 
   int get length => _base.length;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
@@ -483,16 +445,12 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
 
   V remove(Object key) => _base.remove(key) as V;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void removeWhere(bool test(K key, V value)) {
     throw new UnimplementedError('removeWhere');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> retype<K2, V2>() {
     throw new UnimplementedError('retype');
   }
@@ -501,16 +459,12 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
 
   String toString() => _base.toString();
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   V update(K key, V update(V value), {V ifAbsent()}) {
     throw new UnimplementedError('update');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void updateAll(V update(K key, V value)) {
     throw new UnimplementedError('updateAll');
   }

--- a/lib/src/typed_wrappers.dart
+++ b/lib/src/typed_wrappers.dart
@@ -163,6 +163,13 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
 
   Map<int, E> asMap() => new TypeSafeMap<int, E>(_listBase.asMap());
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _listBase.clear();
   }
@@ -243,6 +250,13 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase.retainWhere(_validate(test));
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
+
   Iterable<E> get reversed => new TypeSafeIterable<E>(_listBase.reversed);
 
   void setAll(int index, Iterable<E> iterable) {
@@ -284,6 +298,13 @@ class TypeSafeSet<E> extends TypeSafeIterable<E> implements DelegatingSet<E> {
     _setBase.addAll(elements);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _setBase.clear();
   }
@@ -316,6 +337,13 @@ class TypeSafeSet<E> extends TypeSafeIterable<E> implements DelegatingSet<E> {
     _setBase.retainWhere(_validate(test));
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
+
   Set<E> union(Set<E> other) => new TypeSafeSet<E>(_setBase.union(other));
 }
 
@@ -345,6 +373,13 @@ class TypeSafeQueue<E> extends TypeSafeIterable<E>
     _baseQueue.addLast(value);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Queue<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _baseQueue.clear();
   }
@@ -357,6 +392,13 @@ class TypeSafeQueue<E> extends TypeSafeIterable<E>
 
   void retainWhere(bool test(E element)) {
     _baseQueue.retainWhere(_validate(test));
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Queue<T> retype<T>() {
+    throw new UnimplementedError('retype');
   }
 
   E removeFirst() => _baseQueue.removeFirst() as E;
@@ -390,6 +432,13 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
     // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
     throw new UnimplementedError('addEntries');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError('cast');
   }
 
   void clear() {
@@ -439,6 +488,13 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
   // ignore: override_on_non_overriding_method
   void removeWhere(bool test(K key, V value)) {
     throw new UnimplementedError('removeWhere');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError('retype');
   }
 
   Iterable<V> get values => new TypeSafeIterable<V>(_base.values);

--- a/lib/src/typed_wrappers.dart
+++ b/lib/src/typed_wrappers.dart
@@ -21,6 +21,13 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
 
   bool any(bool test(E element)) => _base.any(_validate(test));
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   bool contains(Object element) => _base.contains(element);
 
   E elementAt(int index) => _base.elementAt(index) as E;
@@ -37,6 +44,13 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       _base.fold(initialValue,
           (previousValue, element) => combine(previousValue, element as E));
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError('followedBy');
+  }
 
   void forEach(void f(E element)) => _base.forEach(_validate(f));
 
@@ -60,10 +74,19 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
   E reduce(E combine(E value, E element)) =>
       _base.reduce((value, element) => combine(value as E, element as E)) as E;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
+
   E get single => _base.single as E;
 
-  E singleWhere(bool test(E element)) =>
-      _base.singleWhere(_validate(test)) as E;
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError('singleWhere:orElse');
+    return _base.singleWhere(_validate(test)) as E;
+  }
 
   Iterable<E> skip(int n) => new TypeSafeIterable<E>(_base.skip(n));
 
@@ -82,6 +105,13 @@ abstract class _TypeSafeIterableBase<E> implements Iterable<E> {
 
   Iterable<E> where(bool test(E element)) =>
       new TypeSafeIterable<E>(_base.where(_validate(test)));
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError('whereType');
+  }
 
   String toString() => _base.toString();
 
@@ -116,6 +146,13 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase[index] = value;
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<E> operator +(List<E> other) {
+    throw new UnimplementedError('+');
+  }
+
   void add(E value) {
     _listBase.add(value);
   }
@@ -134,10 +171,25 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase.fillRange(start, end, fillValue);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  set first(E value) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[0] = value;
+  }
+
   Iterable<E> getRange(int start, int end) =>
       new TypeSafeIterable<E>(_listBase.getRange(start, end));
 
   int indexOf(E element, [int start = 0]) => _listBase.indexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int indexWhere(bool test(E element), [int start = 0]) {
+    throw new UnimplementedError('indexWhere');
+  }
 
   void insert(int index, E element) {
     _listBase.insert(index, element);
@@ -147,8 +199,23 @@ class TypeSafeList<E> extends TypeSafeIterable<E> implements DelegatingList<E> {
     _listBase.insertAll(index, iterable);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  set last(E value) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[this.length - 1] = value;
+  }
+
   int lastIndexOf(E element, [int start]) =>
       _listBase.lastIndexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int lastIndexWhere(bool test(E element), [int start]) {
+    throw new UnimplementedError('lastIndexWhere');
+  }
 
   set length(int newLength) {
     _listBase.length = newLength;
@@ -316,6 +383,15 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
     _base.addAll(other);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('addEntries');
+  }
+
   void clear() {
     _base.clear();
   }
@@ -323,6 +399,15 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
   bool containsKey(Object key) => _base.containsKey(key);
 
   bool containsValue(Object value) => _base.containsValue(value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('entries');
+  }
 
   void forEach(void f(K key, V value)) {
     _base.forEach((key, value) => f(key as K, value as V));
@@ -336,11 +421,41 @@ class TypeSafeMap<K, V> implements DelegatingMap<K, V> {
 
   int get length => _base.length;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('map');
+  }
+
   V putIfAbsent(K key, V ifAbsent()) => _base.putIfAbsent(key, ifAbsent) as V;
 
   V remove(Object key) => _base.remove(key) as V;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError('removeWhere');
+  }
+
   Iterable<V> get values => new TypeSafeIterable<V>(_base.values);
 
   String toString() => _base.toString();
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError('update');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError('updateAll');
+  }
 }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -169,17 +169,15 @@ abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
   /// operations that change the map are disallowed.
   void clear() => _throw();
 
-  @override
-
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
+  @override
   // ignore: override_on_non_overriding_setter
   set first(_) => _throw();
 
-  @override
-
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
+  @override
   // ignore: override_on_non_overriding_setter
   set last(_) => _throw();
 }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -171,13 +171,9 @@ abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
 
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
-  @override
-  // ignore: override_on_non_overriding_setter
   set first(_) => _throw();
 
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
-  @override
-  // ignore: override_on_non_overriding_setter
   set last(_) => _throw();
 }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -168,4 +168,18 @@ abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
   void clear() => _throw();
+
+  @override
+
+  /// Throws an [UnsupportedError];
+  /// operations that change the map are disallowed.
+  // ignore: override_on_non_overriding_setter
+  set first(_) => _throw();
+
+  @override
+
+  /// Throws an [UnsupportedError];
+  /// operations that change the map are disallowed.
+  // ignore: override_on_non_overriding_setter
+  set last(_) => _throw();
 }

--- a/lib/src/wrappers.dart
+++ b/lib/src/wrappers.dart
@@ -21,6 +21,13 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
 
   bool any(bool test(E element)) => _base.any(test);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   bool contains(Object element) => _base.contains(element);
 
   E elementAt(int index) => _base.elementAt(index);
@@ -36,6 +43,13 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
 
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       _base.fold(initialValue, combine);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError('followedBy');
+  }
 
   void forEach(void f(E element)) => _base.forEach(f);
 
@@ -58,9 +72,19 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
 
   E reduce(E combine(E value, E element)) => _base.reduce(combine);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
+
   E get single => _base.single;
 
-  E singleWhere(bool test(E element)) => _base.singleWhere(test);
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError('singleWhere:orElse');
+    return _base.singleWhere(test);
+  }
 
   Iterable<E> skip(int n) => _base.skip(n);
 
@@ -75,6 +99,13 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
   Set<E> toSet() => _base.toSet();
 
   Iterable<E> where(bool test(E element)) => _base.where(test);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
 
   String toString() => _base.toString();
 }
@@ -133,6 +164,13 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase[index] = value;
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<E> operator +(List<E> other) {
+    throw new UnimplementedError('+');
+  }
+
   void add(E value) {
     _listBase.add(value);
   }
@@ -151,9 +189,24 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase.fillRange(start, end, fillValue);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  set first(E value) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[0] = value;
+  }
+
   Iterable<E> getRange(int start, int end) => _listBase.getRange(start, end);
 
   int indexOf(E element, [int start = 0]) => _listBase.indexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int indexWhere(bool test(E element), [int start = 0]) {
+    throw new UnimplementedError('indexWhere');
+  }
 
   void insert(int index, E element) {
     _listBase.insert(index, element);
@@ -163,8 +216,23 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase.insertAll(index, iterable);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  set last(E value) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[this.length - 1] = value;
+  }
+
   int lastIndexOf(E element, [int start]) =>
       _listBase.lastIndexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int lastIndexWhere(bool test(E element), [int start]) {
+    throw new UnimplementedError('lastIndexWhere');
+  }
 
   set length(int newLength) {
     _listBase.length = newLength;
@@ -370,6 +438,15 @@ class DelegatingMap<K, V> implements Map<K, V> {
     _base.addAll(other);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('addEntries');
+  }
+
   void clear() {
     _base.clear();
   }
@@ -377,6 +454,15 @@ class DelegatingMap<K, V> implements Map<K, V> {
   bool containsKey(Object key) => _base.containsKey(key);
 
   bool containsValue(Object value) => _base.containsValue(value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('entries');
+  }
 
   void forEach(void f(K key, V value)) {
     _base.forEach(f);
@@ -390,13 +476,43 @@ class DelegatingMap<K, V> implements Map<K, V> {
 
   int get length => _base.length;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError('map');
+  }
+
   V putIfAbsent(K key, V ifAbsent()) => _base.putIfAbsent(key, ifAbsent);
 
   V remove(Object key) => _base.remove(key);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError('removeWhere');
+  }
+
   Iterable<V> get values => _base.values;
 
   String toString() => _base.toString();
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError('update');
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError('updateAll');
+  }
 }
 
 /// An unmodifiable [Set] view of the keys of a [Map].

--- a/lib/src/wrappers.dart
+++ b/lib/src/wrappers.dart
@@ -181,6 +181,13 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
 
   Map<int, E> asMap() => _listBase.asMap();
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _listBase.clear();
   }
@@ -260,6 +267,13 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase.retainWhere(test);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
+
   Iterable<E> get reversed => _listBase.reversed;
 
   void setAll(int index, Iterable<E> iterable) {
@@ -310,6 +324,13 @@ class DelegatingSet<E> extends DelegatingIterable<E> implements Set<E> {
     _setBase.addAll(elements);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _setBase.clear();
   }
@@ -334,6 +355,13 @@ class DelegatingSet<E> extends DelegatingIterable<E> implements Set<E> {
 
   void retainAll(Iterable<Object> elements) {
     _setBase.retainAll(elements);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError('retype');
   }
 
   void retainWhere(bool test(E element)) {
@@ -385,6 +413,13 @@ class DelegatingQueue<E> extends DelegatingIterable<E> implements Queue<E> {
     _baseQueue.addLast(value);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Queue<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   void clear() {
     _baseQueue.clear();
   }
@@ -397,6 +432,13 @@ class DelegatingQueue<E> extends DelegatingIterable<E> implements Queue<E> {
 
   void retainWhere(bool test(E element)) {
     _baseQueue.retainWhere(test);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Queue<T> retype<T>() {
+    throw new UnimplementedError('retype');
   }
 
   E removeFirst() => _baseQueue.removeFirst();
@@ -451,6 +493,13 @@ class DelegatingMap<K, V> implements Map<K, V> {
     _base.clear();
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError('cast');
+  }
+
   bool containsKey(Object key) => _base.containsKey(key);
 
   bool containsValue(Object value) => _base.containsValue(value);
@@ -496,6 +545,13 @@ class DelegatingMap<K, V> implements Map<K, V> {
     throw new UnimplementedError('removeWhere');
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError('retype');
+  }
+
   Iterable<V> get values => _base.values;
 
   String toString() => _base.toString();
@@ -532,6 +588,13 @@ class MapKeySet<E> extends _DelegatingIterableBase<E>
 
   Iterable<E> get _base => _baseMap.keys;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
+
   bool contains(Object element) => _baseMap.containsKey(element);
 
   bool get isEmpty => _baseMap.isEmpty;
@@ -567,6 +630,13 @@ class MapKeySet<E> extends _DelegatingIterableBase<E>
   /// [Map]s.
   E lookup(Object element) =>
       throw new UnsupportedError("MapKeySet doesn't support lookup().");
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
 
   /// Returns a new set which contains all the elements of [this] and [other].
   ///
@@ -613,6 +683,13 @@ class MapValueSet<K, V> extends _DelegatingIterableBase<V> implements Set<V> {
         _keyForValue = keyForValue;
 
   Iterable<V> get _base => _baseMap.values;
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>() {
+    throw new UnimplementedError('cast');
+  }
 
   bool contains(Object element) {
     if (element != null && element is! V) return false;
@@ -709,6 +786,13 @@ class MapValueSet<K, V> extends _DelegatingIterableBase<V> implements Set<V> {
 
   void retainWhere(bool test(V element)) =>
       removeWhere((element) => !test(element));
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError('retype');
+  }
 
   /// Returns a new set which contains all the elements of [this] and [other].
   ///

--- a/lib/src/wrappers.dart
+++ b/lib/src/wrappers.dart
@@ -21,9 +21,7 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
 
   bool any(bool test(E element)) => _base.any(test);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -44,9 +42,7 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       _base.fold(initialValue, combine);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<E> followedBy(Iterable<E> other) {
     throw new UnimplementedError('followedBy');
   }
@@ -72,9 +68,7 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
 
   E reduce(E combine(E value, E element)) => _base.reduce(combine);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -100,9 +94,7 @@ abstract class _DelegatingIterableBase<E> implements Iterable<E> {
 
   Iterable<E> where(bool test(E element)) => _base.where(test);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
     throw new UnimplementedError("whereType");
   }
@@ -164,9 +156,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase[index] = value;
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<E> operator +(List<E> other) {
     throw new UnimplementedError('+');
   }
@@ -181,9 +171,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
 
   Map<int, E> asMap() => _listBase.asMap();
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -196,9 +184,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase.fillRange(start, end, fillValue);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_setter
   set first(E value) {
     if (this.isEmpty) throw new RangeError.index(0, this);
     this[0] = value;
@@ -208,9 +194,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
 
   int indexOf(E element, [int start = 0]) => _listBase.indexOf(element, start);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   int indexWhere(bool test(E element), [int start = 0]) {
     throw new UnimplementedError('indexWhere');
   }
@@ -223,9 +207,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase.insertAll(index, iterable);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_setter
   set last(E value) {
     if (this.isEmpty) throw new RangeError.index(0, this);
     this[this.length - 1] = value;
@@ -234,9 +216,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
   int lastIndexOf(E element, [int start]) =>
       _listBase.lastIndexOf(element, start);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   int lastIndexWhere(bool test(E element), [int start]) {
     throw new UnimplementedError('lastIndexWhere');
   }
@@ -267,9 +247,7 @@ class DelegatingList<E> extends DelegatingIterable<E> implements List<E> {
     _listBase.retainWhere(test);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -324,9 +302,7 @@ class DelegatingSet<E> extends DelegatingIterable<E> implements Set<E> {
     _setBase.addAll(elements);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -357,9 +333,7 @@ class DelegatingSet<E> extends DelegatingIterable<E> implements Set<E> {
     _setBase.retainAll(elements);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -413,9 +387,7 @@ class DelegatingQueue<E> extends DelegatingIterable<E> implements Queue<E> {
     _baseQueue.addLast(value);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Queue<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -434,9 +406,7 @@ class DelegatingQueue<E> extends DelegatingIterable<E> implements Queue<E> {
     _baseQueue.retainWhere(test);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Queue<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -480,9 +450,7 @@ class DelegatingMap<K, V> implements Map<K, V> {
     _base.addAll(other);
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void addEntries(Iterable<Object> entries) {
     // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
@@ -493,9 +461,7 @@ class DelegatingMap<K, V> implements Map<K, V> {
     _base.clear();
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
     throw new UnimplementedError('cast');
   }
@@ -504,9 +470,7 @@ class DelegatingMap<K, V> implements Map<K, V> {
 
   bool containsValue(Object value) => _base.containsValue(value);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_getter
   Iterable<Null> get entries {
     // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
@@ -525,9 +489,7 @@ class DelegatingMap<K, V> implements Map<K, V> {
 
   int get length => _base.length;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
@@ -538,16 +500,12 @@ class DelegatingMap<K, V> implements Map<K, V> {
 
   V remove(Object key) => _base.remove(key);
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void removeWhere(bool test(K key, V value)) {
     throw new UnimplementedError('removeWhere');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> retype<K2, V2>() {
     throw new UnimplementedError('retype');
   }
@@ -556,16 +514,12 @@ class DelegatingMap<K, V> implements Map<K, V> {
 
   String toString() => _base.toString();
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   V update(K key, V update(V value), {V ifAbsent()}) {
     throw new UnimplementedError('update');
   }
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void updateAll(V update(K key, V value)) {
     throw new UnimplementedError('updateAll');
   }
@@ -588,9 +542,7 @@ class MapKeySet<E> extends _DelegatingIterableBase<E>
 
   Iterable<E> get _base => _baseMap.keys;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -631,9 +583,7 @@ class MapKeySet<E> extends _DelegatingIterableBase<E>
   E lookup(Object element) =>
       throw new UnsupportedError("MapKeySet doesn't support lookup().");
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> retype<T>() {
     throw new UnimplementedError('retype');
   }
@@ -684,9 +634,7 @@ class MapValueSet<K, V> extends _DelegatingIterableBase<V> implements Set<V> {
 
   Iterable<V> get _base => _baseMap.values;
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> cast<T>() {
     throw new UnimplementedError('cast');
   }
@@ -787,9 +735,7 @@ class MapValueSet<K, V> extends _DelegatingIterableBase<V> implements Set<V> {
   void retainWhere(bool test(V element)) =>
       removeWhere((element) => !test(element));
 
-  @override
   // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> retype<T>() {
     throw new UnimplementedError('retype');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.14.4-dev
+version: 1.14.4
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection

--- a/test/wrapper_test.dart
+++ b/test/wrapper_test.dart
@@ -88,8 +88,8 @@ class IterableNSM extends NSM implements Iterable, Set, List, Queue {
   IterableNSM(action(Invocation i)) : super(action);
   toString() => super.noSuchMethod(TO_STRING_INVOCATION) as String;
 
-  abstract Null cast<T>();
-  abstract Null retype<T>();
+  Null cast<T>();
+  Null retype<T>();
 }
 
 // Expector that wraps in DelegatingIterable.

--- a/test/wrapper_test.dart
+++ b/test/wrapper_test.dart
@@ -87,6 +87,9 @@ const TO_STRING_INVOCATION = const SyntheticInvocation(
 class IterableNSM extends NSM implements Iterable, Set, List, Queue {
   IterableNSM(action(Invocation i)) : super(action);
   toString() => super.noSuchMethod(TO_STRING_INVOCATION) as String;
+
+  Null cast<T>() => null;
+  Null retype<T>() => null;
 }
 
 // Expector that wraps in DelegatingIterable.

--- a/test/wrapper_test.dart
+++ b/test/wrapper_test.dart
@@ -88,8 +88,8 @@ class IterableNSM extends NSM implements Iterable, Set, List, Queue {
   IterableNSM(action(Invocation i)) : super(action);
   toString() => super.noSuchMethod(TO_STRING_INVOCATION) as String;
 
-  Null cast<T>() => null;
-  Null retype<T>() => null;
+  abstract Null cast<T>();
+  abstract Null retype<T>();
 }
 
 // Expector that wraps in DelegatingIterable.


### PR DESCRIPTION
Right now, all of the implementations throw (except in trivial cases, like the
EmptyUnmodifiable* classes). They can be updated, typically to call `super` or
reference a wrapped object, once the new methods have been released as part of a
Dart 2.0 release, and this pubspec.yaml updates to guarantee that those
implementations exist.

Also fixes #61 