### PR TITLE
Fix constructor call with type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.5
+
+* Fix issue with EmptyUnmodifiableSet's stubs that were introduced in 1.14.4.
+
 ## 1.14.4
 
 * Add implementation stubs of upcoming Dart 2.0 core library methods, namely

--- a/lib/src/empty_unmodifiable_set.dart
+++ b/lib/src/empty_unmodifiable_set.dart
@@ -20,14 +20,14 @@ class EmptyUnmodifiableSet<E> extends IterableBase<E>
 
   const EmptyUnmodifiableSet();
 
-  EmptyUnmodifiableSet<T> cast<T>() => const EmptyUnmodifiableSet<T>();
+  EmptyUnmodifiableSet<T> cast<T>() => new EmptyUnmodifiableSet<T>();
   bool contains(Object element) => false;
   bool containsAll(Iterable<Object> other) => other.isEmpty;
   Iterable<E> followedBy(Iterable<E> other) => new Set.from(other);
   E lookup(Object element) => null;
-  EmptyUnmodifiableSet<T> retype<T>() => const EmptyUnmodifiableSet<T>();
+  EmptyUnmodifiableSet<T> retype<T>() => new EmptyUnmodifiableSet<T>();
   E singleWhere(bool test(E element), {E orElse()}) => super.singleWhere(test);
-  Iterable<T> whereType<T>() => const EmptyUnmodifiableSet<T>();
+  Iterable<T> whereType<T>() => new EmptyUnmodifiableSet<T>();
   Set<E> toSet() => new Set();
   Set<E> union(Set<E> other) => new Set.from(other);
   Set<E> intersection(Set<Object> other) => new Set();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.14.4+1
+version: 1.14.5
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.14.4
+version: 1.14.4+1
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
Analyzer failed to warn me, via https://github.com/dart-lang/sdk/issues/28750. [The log](https://logs.chromium.org/v/?s=dart%2Fbuildbucket%2Fcr-buildbucket.appspot.com%2F8958436827610302528%2F%2B%2Fsteps%2Fbuild_dart%2F0%2Fstdout).