### PR TITLE
Fix the parameter names in overridden methods to match the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.10
+
+* Fix the parameter names in overridden methods to match the source. 
+
 ## 1.14.9
 
 * Fixed bugs where `QueueList`, `MapKeySet`, and `MapValueSet` did not adhere to

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,6 +20,7 @@ linter:
 
     # Style
     - avoid_init_to_null
+    - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     - await_only_futures
     - camel_case_types

--- a/lib/src/combined_wrappers/combined_list.dart
+++ b/lib/src/combined_wrappers/combined_list.dart
@@ -56,11 +56,11 @@ class CombinedListView<T> extends ListBase<T>
     return null;
   }
 
-  void removeWhere(bool filter(T element)) {
+  void removeWhere(bool test(T element)) {
     _throw();
   }
 
-  void retainWhere(bool filter(T element)) {
+  void retainWhere(bool test(T element)) {
     _throw();
   }
 }

--- a/lib/src/queue_list.dart
+++ b/lib/src/queue_list.dart
@@ -70,9 +70,9 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
     _add(element);
   }
 
-  void addAll(Iterable<E> elements) {
-    if (elements is List) {
-      var list = elements;
+  void addAll(Iterable<E> iterable) {
+    if (iterable is List) {
+      var list = iterable;
       int addCount = list.length;
       int length = this.length;
       if (length + addCount >= _table.length) {
@@ -94,7 +94,7 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
         }
       }
     } else {
-      for (E element in elements) _add(element);
+      for (E element in iterable) _add(element);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.14.9
+version: 1.14.10-dev
 author: Dart Team <misc@dartlang.org>
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
Ensures inherited doc comments remain valid