### PR TITLE
Correctly describe this as a Set not a Map in docs

### DIFF
--- a/lib/src/equality_set.dart
+++ b/lib/src/equality_set.dart
@@ -7,7 +7,7 @@ import 'dart:collection';
 import 'equality.dart';
 import 'wrappers.dart';
 
-/// A [Map] whose key equality is determined by an [Equality] object.
+/// A [Set] whose key equality is determined by an [Equality] object.
 class EqualitySet<E> extends DelegatingSet<E> {
   /// Creates a set with equality based on [equality].
   EqualitySet(Equality<E> equality)


### PR DESCRIPTION
This PR fixes a typo where EqualitySet is described as a Map.

Currently, the docs for EqualitySet incorrectly say it is a map.

See https://docs.flutter.io/flutter/package-collection_collection/package-collection_collection-library.html

```
EqualitySet<E>
A Map whose key equality is determined by an Equality object.
```

and see https://docs.flutter.io/flutter/package-collection_collection/EqualitySet-class.html