### PR TITLE
Deprecate the mapMap utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.14.13-dev
+
+* Deprecate `mapMap`. The Map interface has a `map` call and map literals can
+  use for-loop elements which supersede this method.
+
 ## 1.14.12
 
 * Fix `CombinedMapView.keys`, `CombinedMapView.length`,

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -7,12 +7,11 @@ import 'dart:math' as math;
 
 import 'utils.dart';
 
-// TODO(nweiz): When sdk#26488 is fixed, use overloads to ensure that if [key]
-// or [value] isn't passed, `K2`/`V2` defaults to `K1`/`V1`, respectively.
 /// Creates a new map from [map] with new keys and values.
 ///
 /// The return values of [key] are used as the keys and the return values of
 /// [value] are used as the values for the new map.
+@Deprecated('Use Map.map or a for loop in a Map literal.')
 Map<K2, V2> mapMap<K1, V1, K2, V2>(Map<K1, V1> map,
     {K2 Function(K1, V1) key, V2 Function(K1, V1) value}) {
   key ??= (mapKey, _) => mapKey as K2;

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -10,6 +10,7 @@ void main() {
   group('mapMap()', () {
     test('with an empty map returns an empty map', () {
       expect(
+          // ignore: deprecated_member_use_from_same_package
           mapMap({},
               key: expectAsync2((_, __) {}, count: 0),
               value: expectAsync2((_, __) {}, count: 0)),
@@ -18,6 +19,7 @@ void main() {
 
     test('with no callbacks, returns a copy of the map', () {
       var map = {'foo': 1, 'bar': 2};
+      // ignore: deprecated_member_use_from_same_package
       var result = mapMap(map);
       expect(result, equals({'foo': 1, 'bar': 2}));
 
@@ -27,17 +29,20 @@ void main() {
     });
 
     test("maps the map's keys", () {
+      // ignore: deprecated_member_use_from_same_package
       expect(mapMap({'foo': 1, 'bar': 2}, key: (key, value) => key[value]),
           equals({'o': 1, 'r': 2}));
     });
 
     test("maps the map's values", () {
+      // ignore: deprecated_member_use_from_same_package
       expect(mapMap({'foo': 1, 'bar': 2}, value: (key, value) => key[value]),
           equals({'foo': 'o', 'bar': 'r'}));
     });
 
     test("maps both the map's keys and values", () {
       expect(
+          // ignore: deprecated_member_use_from_same_package
           mapMap({'foo': 1, 'bar': 2},
               key: (key, value) => '$key$value',
               value: (key, value) => key[value]),


### PR DESCRIPTION
This utility hasn't been useful since `Map` got a `.map` call.