### PR TITLE
Remove private typedefs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,6 +20,7 @@ linter:
 
     # Style
     - avoid_init_to_null
+    - avoid_private_typedef_functions
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     - await_only_futures

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -6,10 +6,6 @@ import 'dart:collection';
 
 import 'utils.dart';
 
-typedef _Canonicalize<C, K> = C Function(K key);
-
-typedef _IsValidKey = bool Function(Object key);
-
 /// A map whose keys are converted to canonical values of type `C`.
 ///
 /// This is useful for using case-insensitive String keys, for example. It's
@@ -20,9 +16,9 @@ typedef _IsValidKey = bool Function(Object key);
 /// By default, `null` is allowed as a key. It can be forbidden via the
 /// `isValidKey` parameter.
 class CanonicalizedMap<C, K, V> implements Map<K, V> {
-  final _Canonicalize<C, K> _canonicalize;
+  final C Function(K) _canonicalize;
 
-  final _IsValidKey _isValidKeyFn;
+  final bool Function(Object) _isValidKeyFn;
 
   final _base = <C, Pair<K, V>>{};
 

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -30,8 +30,6 @@ abstract class Equality<E> {
   bool isValidKey(Object o);
 }
 
-typedef _GetKey<E, F> = F Function(E object);
-
 /// Equality of objects based on derived values.
 ///
 /// For example, given the class:
@@ -49,27 +47,26 @@ typedef _GetKey<E, F> = F Function(E object);
 /// It's also possible to pass an additional equality instance that should be
 /// used to compare the value itself.
 class EqualityBy<E, F> implements Equality<E> {
-  // Returns a derived value F from an object E.
-  final _GetKey<E, F> _getKey;
+  final F Function(E) _comparisonKey;
 
-  // Determines equality between two values of F.
   final Equality<F> _inner;
 
-  EqualityBy(F Function(E) getKey,
+  EqualityBy(F Function(E) comparisonKey,
       [Equality<F> inner = const DefaultEquality()])
-      : _getKey = getKey,
+      : _comparisonKey = comparisonKey,
         _inner = inner;
 
   @override
-  bool equals(E e1, E e2) => _inner.equals(_getKey(e1), _getKey(e2));
+  bool equals(E e1, E e2) =>
+      _inner.equals(_comparisonKey(e1), _comparisonKey(e2));
 
   @override
-  int hash(E e) => _inner.hash(_getKey(e));
+  int hash(E e) => _inner.hash(_comparisonKey(e));
 
   @override
   bool isValidKey(Object o) {
     if (o is E) {
-      final value = _getKey(o);
+      final value = _comparisonKey(o);
       return value is F && _inner.isValidKey(value);
     }
     return false;

--- a/lib/src/wrappers.dart
+++ b/lib/src/wrappers.dart
@@ -7,8 +7,6 @@ import 'dart:math' as math;
 
 import 'unmodifiable_wrappers.dart';
 
-typedef _KeyForValue<K, V> = K Function(V value);
-
 /// A base class for delegating iterables.
 ///
 /// Subclasses can provide a [_base] that should be delegated to. Unlike
@@ -688,7 +686,7 @@ class MapKeySet<E> extends _DelegatingIterableBase<E>
 /// Effectively, the map will act as a kind of index for the set.
 class MapValueSet<K, V> extends _DelegatingIterableBase<V> implements Set<V> {
   final Map<K, V> _baseMap;
-  final _KeyForValue<K, V> _keyForValue;
+  final K Function(V) _keyForValue;
 
   /// Creates a new [MapValueSet] based on [base].
   ///


### PR DESCRIPTION
https://dart.dev/guides/language/effective-dart/design#prefer-inline-function-types-over-typedefs

Also drop some comments redundant against a field type and remove a
member named "get*" with a more descriptive name.