### PR TITLE
Remove new keyword from code samples

### DIFF
--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -43,7 +43,7 @@ typedef _GetKey<E, F> = F Function(E object);
 ///
 /// The following [Equality] considers employees with the same IDs to be equal:
 /// ```dart
-/// new EqualityBy((Employee e) => e.employmentId);
+/// EqualityBy((Employee e) => e.employmentId);
 /// ```
 ///
 /// It's also possible to pass an additional equality instance that should be

--- a/lib/src/union_set_controller.dart
+++ b/lib/src/union_set_controller.dart
@@ -12,7 +12,7 @@ import 'union_set.dart';
 /// ```dart
 /// class Engine {
 ///   Set<Test> get activeTests => _activeTestsGroup.set;
-///   final _activeTestsGroup = new UnionSetController<Test>();
+///   final _activeTestsGroup = UnionSetController<Test>();
 ///
 ///   void addSuite(Suite suite) {
 ///     _activeTestsGroup.add(suite.tests);

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -109,7 +109,7 @@ class UnmodifiableSetView<E> extends DelegatingSet<E>
 
   /// An unmodifiable empty set.
   ///
-  /// This is the same as `new UnmodifiableSetView(new Set())`, except that it
+  /// This is the same as `UnmodifiableSetView(Set())`, except that it
   /// can be used in const contexts.
   const factory UnmodifiableSetView.empty() = EmptyUnmodifiableSet<E>;
 }

--- a/test/priority_queue_test.dart
+++ b/test/priority_queue_test.dart
@@ -15,7 +15,7 @@ void main() {
 }
 
 void testDefault() {
-  test('new PriorityQueue() returns a HeapPriorityQueue', () {
+  test('PriorityQueue() returns a HeapPriorityQueue', () {
     expect(PriorityQueue<int>(), TypeMatcher<HeapPriorityQueue<int>>());
   });
   testInt(() => PriorityQueue<int>());

--- a/test/queue_list_test.dart
+++ b/test/queue_list_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 void main() {
-  group('new QueueList()', () {
+  group('QueueList()', () {
     test('creates an empty QueueList', () {
       expect(QueueList(), isEmpty);
     });
@@ -18,7 +18,7 @@ void main() {
     });
   });
 
-  test('new QueueList.from() copies the contents of an iterable', () {
+  test('QueueList.from() copies the contents of an iterable', () {
     expect(QueueList.from([1, 2, 3].skip(1)), equals([2, 3]));
   });
 
@@ -298,7 +298,7 @@ void main() {
 /// Returns a queue whose internal ring buffer is full enough that adding a new
 /// element will expand it.
 QueueList atCapacity() {
-  // Use addAll because [new QueueList.from(List)] won't use the default initial
+  // Use addAll because `QueueList.from(list)` won't use the default initial
   // capacity of 8.
   return QueueList()..addAll([1, 2, 3, 4, 5, 6, 7]);
 }


### PR DESCRIPTION
Find the word `new` where it is use in a context referencing Dart code
and remove it to match the style of Dart we write.

Change a `[]` in an implementation comment to backticks since `[]`
should be use in Doc comments and does not have meaning in other
comments.