### PR TITLE
Replace a use of putIfAbsent with ??=

### DIFF
--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -49,8 +49,7 @@ Map<K, V> mergeMaps<K, V>(Map<K, V> map1, Map<K, V> map2,
 Map<T, List<S>> groupBy<S, T>(Iterable<S> values, T Function(S) key) {
   var map = <T, List<S>>{};
   for (var element in values) {
-    var list = map.putIfAbsent(key(element), () => []);
-    list.add(element);
+    (map[key(element)] ??= []).add(element);
   }
   return map;
 }


### PR DESCRIPTION
Because it avoids using a closure, it seems that ??= [] can be used with better performance than putIfAbsent in groupBy.