### PR TITLE
update deps and fix tests so they run with --null-safety

### DIFF
--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -176,8 +176,8 @@ void mergeSort<T>(List<T> list,
   _mergeSort<T>(list, compare, middle, end, scratchSpace, 0);
   var firstTarget = end - firstLength;
   _mergeSort<T>(list, compare, start, middle, list, firstTarget);
-  _merge<T>(compare, list, firstTarget, end, scratchSpace, 0, secondLength, list,
-      start);
+  _merge<T>(compare, list, firstTarget, end, scratchSpace.cast<T>(), 0,
+      secondLength, list, start);
 }
 
 /// Performs an insertion sort into a potentially different list than the
@@ -230,8 +230,8 @@ void _mergeSort<T>(List<T> list, int Function(T, T) compare, int start, int end,
   // Sort the first half into the end of the source area.
   _mergeSort<T>(list, compare, start, middle, list, middle);
   // Merge the two parts into the target area.
-  _merge<T>(compare, list, middle, middle + firstLength, target, targetMiddle,
-      targetMiddle + secondLength, target, targetOffset);
+  _merge<T>(compare, list, middle, middle + firstLength, target.cast<T>(),
+      targetMiddle, targetMiddle + secondLength, target, targetOffset);
 }
 
 /// Merges two lists into a target list.
@@ -247,7 +247,7 @@ void _merge<T>(
     List<T> firstList,
     int firstStart,
     int firstEnd,
-    List<T?> secondList,
+    List<T> secondList,
     int secondStart,
     int secondEnd,
     List<T?> target,

--- a/lib/src/queue_list.dart
+++ b/lib/src/queue_list.dart
@@ -127,7 +127,7 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
   @override
   E removeFirst() {
     if (_head == _tail) throw StateError('No element');
-    var result = _table[_head]!;
+    var result = _table[_head] as E;
     _table[_head] = null;
     _head = (_head + 1) & (_table.length - 1);
     return result;
@@ -150,6 +150,15 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
   @override
   set length(int value) {
     if (value < 0) throw RangeError('Length $value may not be negative.');
+    if (value > length) {
+      try {
+        null as E;
+      } on CastError {
+        throw UnsupportedError(
+            'The length can only be increased when the element type is '
+            'nullable, but the current element type is `$E`.');
+      }
+    }
 
     var delta = value - length;
     if (delta >= 0) {
@@ -177,7 +186,7 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
       throw RangeError('Index $index must be in the range [0..$length).');
     }
 
-    return _table[(_head + index) & (_table.length - 1)]!;
+    return _table[(_head + index) & (_table.length - 1)] as E;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependency_overrides:
   path:
     git:
       url: git://github.com/dart-lang/path.git
-      ref: null_safety_insert_workaround
+      ref: null_safety
   source_span:
     git:
       url: git://github.com/dart-lang/source_span.git
@@ -58,3 +58,13 @@ dependency_overrides:
       url: git://github.com/dart-lang/test.git
       ref: null_safety
       path: pkgs/test_api
+  test_core:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test_core
+  test:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test

--- a/test/queue_list_test.dart
+++ b/test/queue_list_test.dart
@@ -136,13 +136,17 @@ void main() {
     });
 
     test('grows a smaller queue', () {
-      var queue = QueueList.from([1, 2, 3]);
+      var queue = QueueList<int?>.from([1, 2, 3]);
       queue.length = 5;
       expect(queue, equals([1, 2, 3, null, null]));
     });
 
     test('throws a RangeError if length is less than 0', () {
       expect(() => QueueList().length = -1, throwsRangeError);
+    });
+
+    test('throws an UnsupportedError if element type is non-nullable', () {
+      expect(() => QueueList<int>().length = 1, throwsUnsupportedError);
     });
   });
 


### PR DESCRIPTION
Note that wrapper_test.dart was not migrated as it is incompatible, https://github.com/dart-lang/collection/issues/127.