### PR TITLE
Rewrite doc comments to refer to TypeError

### DIFF
--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -12,7 +12,8 @@ import 'utils.dart';
 /// is unpredictable.
 ///
 /// If [compare] is omitted, this defaults to calling [Comparable.compareTo] on
-/// the objects. If any object is not [Comparable], this throws a [CastError].
+/// the objects. If any object is not [Comparable], this throws a [TypeError]
+/// (`CastError` on some SDK versions).
 ///
 /// Returns -1 if [value] is not in the list by default.
 int binarySearch<T>(List<T> sortedList, T value, {int Function(T, T) compare}) {
@@ -40,7 +41,8 @@ int binarySearch<T>(List<T> sortedList, T value, {int Function(T, T) compare}) {
 /// is unpredictable.
 ///
 /// If [compare] is omitted, this defaults to calling [Comparable.compareTo] on
-/// the objects. If any object is not [Comparable], this throws a [CastError].
+/// the objects. If any object is not [Comparable], this throws a [TypeError]
+/// (`CastError` on some SDK versions).
 ///
 /// Returns [sortedList.length] if all the items in [sortedList] compare less
 /// than [value].
@@ -96,7 +98,8 @@ void _reverse(List list, int start, int end) {
 /// insertion sort.
 ///
 /// If [compare] is omitted, this defaults to calling [Comparable.compareTo] on
-/// the objects. If any object is not [Comparable], this throws a [CastError].
+/// the objects. If any object is not [Comparable], this throws a [TypeError]
+/// (`CastError` on some SDK versions).
 ///
 /// Insertion sort is a simple sorting algorithm. For `n` elements it does on
 /// the order of `n * log(n)` comparisons but up to `n` squared moves. The
@@ -139,7 +142,8 @@ const int _MERGE_SORT_LIMIT = 32;
 /// merge sort algorithm.
 ///
 /// If [compare] is omitted, this defaults to calling [Comparable.compareTo] on
-/// the objects. If any object is not [Comparable], this throws a [CastError].
+/// the objects. If any object is not [Comparable], this throws a [TypeError]
+/// (`CastError` on some SDK versions).
 ///
 /// Merge-sorting works by splitting the job into two parts, sorting each
 /// recursively, and then merging the two sorted parts.

--- a/test/queue_list_test.dart
+++ b/test/queue_list_test.dart
@@ -284,7 +284,8 @@ void main() {
     );
     expect(
       () => numQueue.add(1),
-      throwsTypeError,
+      // ignore: deprecated_member_use
+      throwsA(isA<CastError>()),
       skip: isDart2 ? false : 'In Dart1 a TypeError is not thrown',
     );
   });

--- a/test/queue_list_test.dart
+++ b/test/queue_list_test.dart
@@ -284,7 +284,7 @@ void main() {
     );
     expect(
       () => numQueue.add(1),
-      throwsCastError,
+      throwsTypeError,
       skip: isDart2 ? false : 'In Dart1 a TypeError is not thrown',
     );
   });

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,7 +4,7 @@
 
 import 'package:test/test.dart';
 
-final Matcher throwsCastError = throwsA(TypeMatcher<CastError>());
+final Matcher throwsTypeError = throwsA(TypeMatcher<TypeError>());
 
 /// A hack to determine whether we are running in a Dart 2 runtime.
 final bool isDart2 = _isTypeArgString('');

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,10 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
-
-final Matcher throwsTypeError = throwsA(TypeMatcher<TypeError>());
-
 /// A hack to determine whether we are running in a Dart 2 runtime.
 final bool isDart2 = _isTypeArgString('');
 bool _isTypeArgString<T>(T arg) {


### PR DESCRIPTION
This will be the type going forward. Keep a reference to `CastError` for
now, we can drop it after a few SDK releases.

Check for `TypeError` in test. Going forward these will both match until
`CastError` is removed entirely.