### PR TITLE
Prep for merge back into master and publishing of the nnbd release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,37 @@ language: dart
 dart:
 - be/raw/latest
 
-dart_task:
-- test
-- dartfmt
-- dartanalyzer: --fatal-infos --fatal-warnings .
+jobs:
+  include:
+    - stage: analyze_and_format
+      name: "Analyze lib/"
+      dart: be/raw/latest
+      os: linux
+      script: dartanalyzer --fatal-warnings --fatal-infos lib/
+    - stage: analyze_and_format
+      name: "Analyze test/"
+      dart: be/raw/latest
+      os: linux
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
+    - stage: analyze_and_format
+      name: "Format"
+      dart: be/raw/latest
+      os: linux
+      script: dartfmt -n --set-exit-if-changed .
+    - stage: test
+      name: "Vm Tests"
+      dart: be/raw/latest
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p vm 
+    - stage: test
+      name: "Web Tests"
+      dart: be/raw/latest
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p chrome
+
+stages:
+  - analyze_and_format
+  - test
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,16 @@
 language: dart
 
 dart:
-- 2.3.0
-- dev
+- be/raw/latest
 
 dart_task:
 - test
-
-matrix:
-  include:
-  # Only validate formatting using the dev release
-  - dart: dev
-    dart_task: dartfmt
-  - dart: dev
-    dart_task:
-      dartanalyzer: --fatal-infos --fatal-warnings .
-  - dart: 2.3.0
-    dart_task:
-      dartanalyzer: --fatal-warnings .
+- dartfmt
+- dartanalyzer: --fatal-infos --fatal-warnings .
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master]
+  only: [master, null_safety]
 
 # Incremental pub cache and builds.
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.15.0-nnbd
+
+Pre-release for the null safety migration of this package.
+
+Note that `1.15.0` may not be the final stable null safety release version,
+we reserve the right to release it as a `2.0.0` breaking change.
+
+This release will be pinned to only allow pre-release sdk versions starting
+from `2.9.0-dev.18.0`, which is the first version where this package will
+appear in the null safety allow list.
+
 ## 1.14.13
 
 * Deprecate `mapMap`. The Map interface has a `map` call and map literals can

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,8 @@ analyzer:
     unused_import: error
     unused_local_variable: error
     dead_code: error
+  enable-experiment:
+    - non-nullable
 
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,8 +5,6 @@ analyzer:
     unused_import: error
     unused_local_variable: error
     dead_code: error
-  enable-experiment:
-    - non-nullable
 
 linter:
   rules:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Collections and utilities functions and classes related to collecti
 homepage: https://www.github.com/dart-lang/collection
 
 environment:
-  sdk: '>=2.9.0-1 <3.0.0'
+  sdk: '>=2.9.0-18.0 <2.9.0'
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.14.13
+version: 1.15.0-nnbd
 
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection
@@ -24,6 +24,10 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/charcode.git
       ref: null_safety
+  js:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      path: pkg/js
   matcher:
     git:
       url: git://github.com/dart-lang/matcher.git
@@ -44,6 +48,14 @@ dependency_overrides:
   pool:
     git:
       url: git://github.com/dart-lang/pool.git
+      ref: null_safety
+  source_maps:
+    git:
+      url: git://github.com/dart-lang/source_maps.git
+      ref: null_safety
+  source_map_stack_trace:
+    git:
+      url: git://github.com/dart-lang/source_map_stack_trace.git
       ref: null_safety
   source_span:
     git:

--- a/test/wrapper_test.dart
+++ b/test/wrapper_test.dart
@@ -4,6 +4,7 @@
 
 /// Tests wrapper utilities.
 
+@TestOn('vm')
 import 'dart:collection';
 
 import 'package:collection/collection.dart';


### PR DESCRIPTION
Updates travis to run on be/raw/latest, and test with null safety enabled.

- Runs the analyzer on the `lib` dir without the explicit flag to verify the allow list functionality
- Runs the analyzer on the `test` dir with the flag since the allow list appears to have only been implemented for `package:` uris. cc @leafpetersen was this the intention? It seems wrong to me, given that the notion of a package has been expanded to its entire root directory.
- Runs tests on the vm and ddc, all in strong mode currently
- Updates the sdk constraint to `>=2.9.0-18.0 <2.9.0` (this allows dev or beta releases)
- Updates the release version to `1.15.0-nnbd`. Note that this is the actual version number I propose we publish as, cc @kevmoo .

If we want a solution for running weak mode (non-opted in) tests, that will need to happen separately. 