### PR TITLE
prep the release for 2.10 dev sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,27 @@ jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze lib/"
-      dart: preview/raw/2.10.0-0.0-dev
+      dart: preview/raw/2.10.0-0.1-dev
       os: linux
       script: dartanalyzer --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze test/"
-      dart: preview/raw/2.10.0-0.0-dev
+      dart: preview/raw/2.10.0-0.1-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
     - stage: analyze_and_format
       name: "Format"
-      dart: preview/raw/2.10.0-0.0-dev
+      dart: preview/raw/2.10.0-0.1-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: preview/raw/2.10.0-0.0-dev
+      dart: preview/raw/2.10.0-0.1-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm 
     - stage: test
       name: "Web Tests"
-      dart: preview/raw/2.10.0-0.0-dev
+      dart: preview/raw/2.10.0-0.1-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- preview/raw/2.10.0-0.0-dev
+- preview/raw/2.10.0-0.1-dev
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,33 @@
 language: dart
 
 dart:
-- preview/raw/2.10.0-0.1-dev
+- preview/raw/2.10.0-0.2-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze lib/"
-      dart: preview/raw/2.10.0-0.1-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze test/"
-      dart: preview/raw/2.10.0-0.1-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
     - stage: analyze_and_format
       name: "Format"
-      dart: preview/raw/2.10.0-0.1-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: preview/raw/2.10.0-0.1-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm 
     - stage: test
       name: "Web Tests"
-      dart: preview/raw/2.10.0-0.1-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,33 @@
 language: dart
 
 dart:
-- dev
+- preview/raw/2.10.0-0.0-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze lib/"
-      dart: dev
+      dart: preview/raw/2.10.0-0.0-dev
       os: linux
       script: dartanalyzer --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze test/"
-      dart: dev
+      dart: preview/raw/2.10.0-0.0-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
     - stage: analyze_and_format
       name: "Format"
-      dart: dev
+      dart: preview/raw/2.10.0-0.0-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.0-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm 
     - stage: test
       name: "Web Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.0-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.0-nullsafety.2
+
+Update for the 2.10 dev sdk.
+
 ## 1.15.0-nullsafety.1-dev
 
 ## 1.15.0-nullsafety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: collection
-version: 1.15.0-nullsafety.1-dev
+version: 1.15.0-nullsafety.2
 
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection
 
 environment:
-  sdk: '>=2.9.0-20.0 <2.9.0'
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,3 +92,4 @@ dependency_overrides:
       url: git://github.com/dart-lang/test.git
       ref: null_safety
       path: pkgs/test
+  typed_data: 1.3.0-nnbd

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,4 +92,4 @@ dependency_overrides:
       url: git://github.com/dart-lang/test.git
       ref: null_safety
       path: pkgs/test
-  typed_data: 1.3.0-nnbd
+  typed_data: 1.3.0-nullsafety


### PR DESCRIPTION
Not quite ready to merge (we should publish the version for the 2.9 stable sdk first I think, which is why I let an extra version in there).

@whesse built us a custom sdk with the right version so that travis will be happy. It is a bit of a weird sdk in that still only requires language version `2.9` for our transitive deps, but that makes things a bit easier.