### PR TITLE
Add a changelog entry for `toUnorderedList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.15.0-nullsafety.3
+## 1.15.0-nullsafety.3-dev
 
+* Add `toUnorderedList` method on `PriorityQueue`.
 * Make `HeapPriorityQueue`'s `remove` and `contains` methods
   use `==` for equality checks.
   Previously used `comparison(a, b) == 0` as criteria, but it's possible

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.15.0-nullsafety.3
+version: 1.15.0-nullsafety.3-dev
 
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
This was missed in the PR which added the API.

Also add a `-dev` suffix to the pubspec and changelog version numbers to
make it clear that this is not published yet.