### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.15.0-nullsafety.3-dev
+## 1.15.0-nullsafety.3
 
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
 * Add `toUnorderedList` method on `PriorityQueue`.
 * Make `HeapPriorityQueue`'s `remove` and `contains` methods
   use `==` for equality checks.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: collection
-version: 1.15.0-nullsafety.3-dev
+version: 1.15.0-nullsafety.3
 
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection
 
 environment:
-  sdk: '>=2.10.0-78 <2.10.0'
+  sdk: '>=2.10.0-78 <2.11.0'
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.