### PR TITLE
Avoid public `late final` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.15.0-nullsafety.4-dev
+
+* Remove the unusable setter `UnionSetController.set=`. This was mistakenly
+  added to the public API but could never be called.
+
 ## 1.15.0-nullsafety.3
 
 * Allow 2.10 stable and 2.11.0 dev SDK versions.

--- a/lib/src/union_set_controller.dart
+++ b/lib/src/union_set_controller.dart
@@ -23,7 +23,8 @@ import 'union_set.dart';
 /// ```
 class UnionSetController<E> {
   /// The [UnionSet] that provides a view of the union of sets in [this].
-  late final UnionSet<E> set;
+  UnionSet<E> get set => _set;
+  late final UnionSet<E> _set;
 
   /// The sets whose union is exposed through [set].
   final _sets = <Set<E>>{};
@@ -34,7 +35,7 @@ class UnionSetController<E> {
   /// disjoint—that is, that they contain no elements in common. This makes
   /// many operations including [length] more efficient.
   UnionSetController({bool disjoint = false}) {
-    set = UnionSet<E>(_sets, disjoint: disjoint);
+    _set = UnionSet<E>(_sets, disjoint: disjoint);
   }
 
   /// Adds the contents of [component] to [set].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.15.0-nullsafety.3
+version: 1.15.0-nullsafety.4-dev
 
 description: Collections and utilities functions and classes related to collections.
 homepage: https://www.github.com/dart-lang/collection


### PR DESCRIPTION
This had been set in the constructor because it needs to reference
a field on `this`. A new capability with late final files is to allow an
initializer expression referencing `this`. This approach also avoids
introducing a setter to the public API. Technically it's statically
breaking to remove the setter, but since it could never be called at
runtime this is safe to do.