### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.15.0-nullsafety.5
 
 * Fix typo in extension method `expandIndexed`.
+* Update sdk constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
 
 ## 1.15.0-nullsafety.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Collections and utilities functions and classes related to collecti
 homepage: https://github.com/dart-lang/collection
 
 environment:
-  sdk: '>=2.10.0-78 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
   pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.