### PR TITLE
Add an empty unmodifiable map implementation

### DIFF
--- a/lib/src/empty_unmodifiable_map.dart
+++ b/lib/src/empty_unmodifiable_map.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'unmodifiable_wrappers.dart';
+
+/// An unmodifiable, empty map which can be constant.
+class EmptyUnmodifiableMap<K, V>
+    with UnmodifiableMapMixin<K, V>
+    implements UnmodifiableMapView<K, V> {
+  const EmptyUnmodifiableMap();
+
+  @override
+  V? operator [](Object? key) => null;
+  @override
+  Map<RK, RV> cast<RK, RV>() => EmptyUnmodifiableMap<RK, RV>();
+  @override
+  bool containsKey(Object? key) => false;
+  @override
+  bool containsValue(Object? value) => false;
+  @override
+  Iterable<MapEntry<K, V>> get entries => Iterable<MapEntry<K, V>>.empty();
+  @override
+  void forEach(void Function(K key, V value) f) {}
+  @override
+  bool get isEmpty => true;
+  @override
+  bool get isNotEmpty => false;
+  @override
+  Iterable<K> get keys => Iterable<K>.empty();
+  @override
+  int get length => 0;
+  @override
+  Map<K2, V2> map<K2, V2>(MapEntry<K2, V2> Function(K key, V value) f) =>
+      EmptyUnmodifiableMap<K2, V2>();
+  @override
+  Iterable<V> get values => Iterable<V>.empty();
+}

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -177,17 +177,12 @@ abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
   @override
-  V putIfAbsent(K key, V Function() ifAbsent) => _throw();
-
-  /// Throws an [UnsupportedError];
-  /// operations that change the map are disallowed.
-  @override
   void addAll(Map<K, V> other) => _throw();
 
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
   @override
-  V remove(Object? key) => _throw();
+  void addEntries(Iterable<MapEntry<K, V>> entries) => _throw();
 
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
@@ -196,9 +191,26 @@ abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
 
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
-  set first(_) => _throw();
+  @override
+  V? remove(Object? key) => _throw();
 
   /// Throws an [UnsupportedError];
   /// operations that change the map are disallowed.
-  set last(_) => _throw();
+  @override
+  void removeWhere(bool Function(K key, V value) test) => _throw();
+
+  /// Throws an [UnsupportedError];
+  /// operations that change the map are disallowed.
+  @override
+  V putIfAbsent(K key, V Function() ifAbsent) => _throw();
+
+  /// Throws an [UnsupportedError];
+  /// operations that change the map are disallowed.
+  @override
+  V update(K key, V Function(V) update, {V Function()? ifAbsent}) => _throw();
+
+  /// Throws an [UnsupportedError];
+  /// operations that change the map are disallowed.
+  @override
+  void updateAll(V Function(K key, V value) update) => _throw();
 }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -23,9 +23,9 @@ class NonGrowableListView<E> extends DelegatingList<E>
   NonGrowableListView(List<E> listBase) : super(listBase);
 }
 
-/// Mixin class that implements a throwing version of all list operations that
+/// Mixin that implements a throwing version of all list operations that
 /// change the List's length.
-abstract class NonGrowableListMixin<E> implements List<E> {
+mixin NonGrowableListMixin<E> implements List<E> {
   static Never _throw() {
     throw UnsupportedError('Cannot change the length of a fixed-length list');
   }
@@ -114,9 +114,9 @@ class UnmodifiableSetView<E> extends DelegatingSet<E>
   const factory UnmodifiableSetView.empty() = EmptyUnmodifiableSet<E>;
 }
 
-/// Mixin class that implements a throwing version of all set operations that
+/// Mixin that implements a throwing version of all set operations that
 /// change the Set.
-abstract class UnmodifiableSetMixin<E> implements Set<E> {
+mixin UnmodifiableSetMixin<E> implements Set<E> {
   static Never _throw() {
     throw UnsupportedError('Cannot modify an unmodifiable Set');
   }
@@ -162,9 +162,9 @@ abstract class UnmodifiableSetMixin<E> implements Set<E> {
   void clear() => _throw();
 }
 
-/// Mixin class that implements a throwing version of all map operations that
+/// Mixin that implements a throwing version of all map operations that
 /// change the Map.
-abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
+mixin UnmodifiableMapMixin<K, V> implements Map<K, V> {
   static Never _throw() {
     throw UnsupportedError('Cannot modify an unmodifiable Map');
   }


### PR DESCRIPTION
Adds an `EmptyUnmodifiableMap` implementation which provides a `const` constructor.

The `Mixin` classes within `unmodifiable_wrappers.dart` were changed from `abstract class` to `mixin` to modernize the code. This allowed the `EmptyUnmodifiableMap` to have a `const` constructor without also defining a `const` constructor in `UnmodifiableMapMixin`.