### PR TITLE
Revert "Remove unnecessary import (#175)"

### DIFF
--- a/lib/src/empty_unmodifiable_set.dart
+++ b/lib/src/empty_unmodifiable_set.dart
@@ -6,6 +6,8 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart';
 
+import 'unmodifiable_wrappers.dart';
+
 /// An unmodifiable, empty set which can be constant.
 class EmptyUnmodifiableSet<E> extends IterableBase<E>
     with UnmodifiableSetMixin<E>


### PR DESCRIPTION
This reverts commit b386f6c68f9f6c7c457bab4954589bdecd0c968e.

Reverting to publish with exactly the same `lib/` content as the
previous publish.