### PR TITLE
add mapNotNull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add `BoolList` class for space-efficient lists of boolean values.
 * Use a stable sort algorithm in the `IterableExtension.sortedBy` method.
 * Add `min`, `max`, `minOrNull` and `maxOrNull` getters to `IterableDoubleExtension`, `IterableNumberExtension` and `IterableIntegerExtension`
+* Add `IterableExtension.mapNotNull` method.
 
 ## 1.15.0
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -169,7 +169,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// Returns an iterable containing only the non-`null` results
   /// of applying the given [transform] function to each element in this iterable.
   Iterable<R> mapNotNull<R extends Object>(R? Function(T) transform) sync* {
-    for (final element in this) {
+    for (var element in this) {
       final value = transform(element);
       if (value != null) {
         yield value;

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -166,8 +166,13 @@ extension IterableExtension<T> on Iterable<T> {
     }
   }
 
-  /// Returns an iterable containing only the non-`null` results
-  /// of applying the given [transform] function to each element in this iterable.
+  /// The non-`null` results of calling [transform] on the elements of [this].
+  ///
+  /// Returns a lazy iterable which calls [transform]
+  /// on the elements of this iterable in iteration order,
+  /// then emits only the non-`null` values.
+  ///
+  /// If [transform] throws, the iteration is terminated.
   Iterable<R> mapNotNull<R extends Object>(R? Function(T) transform) sync* {
     for (var element in this) {
       final value = transform(element);

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -175,7 +175,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// If [transform] throws, the iteration is terminated.
   Iterable<R> mapNotNull<R extends Object>(R? Function(T) transform) sync* {
     for (var element in this) {
-      final value = transform(element);
+      var value = transform(element);
       if (value != null) {
         yield value;
       }

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -166,6 +166,17 @@ extension IterableExtension<T> on Iterable<T> {
     }
   }
 
+  /// Returns an iterable containing only the non-`null` results
+  /// of applying the given [transform] function to each element in this iterable.
+  Iterable<R> mapNotNull<R extends Object>(R? Function(T) transform) sync* {
+    for (final element in this) {
+      final value = transform(element);
+      if (value != null) {
+        yield value;
+      }
+    }
+  }
+
   /// Maps each element and its index to a new value.
   Iterable<R> mapIndexed<R>(R Function(int index, T element) convert) sync* {
     var index = 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,5 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety
-  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0
+  test: ^1.16.4

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -243,6 +243,31 @@ void main() {
           expect(log, [0, 'a', 1, 'b']);
         });
       });
+      group('.mapNotNull', () {
+        test('empty', () {
+          expect(iterable(<String>[]).mapNotNull(unreachable), isEmpty);
+        });
+        test('single', () {
+          expect(iterable(<String>['1']).mapNotNull(int.tryParse), [1]);
+          expect(iterable(<String>['#']).mapNotNull(int.tryParse), isEmpty);
+        });
+        test('multiple', () {
+          expect(iterable(<String>['1', '2', '3']).mapNotNull(int.tryParse),
+              [1, 2, 3]);
+          expect(iterable(<String>['1', '#', '3']).mapNotNull(int.tryParse),
+              [1, 3]);
+          final transform = (int? i) =>
+              i == null || i.isEven ? null : [i.toString(), (i + 1).toString()];
+          expect(
+              iterable(<int?>[1, 2, 3, null, 4, 5, 6, null])
+                  .mapNotNull(transform),
+              [
+                ['1', '2'],
+                ['3', '4'],
+                ['5', '6']
+              ]);
+        });
+      });
       group('.mapIndexed', () {
         test('empty', () {
           expect(iterable(<String>[]).mapIndexed(unreachable), isEmpty);

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -269,7 +269,7 @@ void main() {
               [1, 2, 3]);
           expect(iterable(<String>['1', '#', '3']).mapNotNull(int.tryParse),
               [1, 3]);
-          final transform = (int? i) =>
+          List<String>? transform(int? i) =>
               i == null || i.isEven ? null : [i.toString(), (i + 1).toString()];
           expect(
               iterable(<int?>[1, 2, 3, null, 4, 5, 6, null])


### PR DESCRIPTION
- #180 
Returns an iterable containing only the non-`null` results
of applying the given [transform] function to each element in this iterable.
