### PR TITLE
Unorderd list equality

### DIFF
--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -260,6 +260,20 @@ class UnorderedIterableEquality<E> extends _UnorderedEquality<E, Iterable<E>?> {
   bool isValidKey(Object? o) => o is Iterable<E>;
 }
 
+/// Equality of the elements of two lists without considering order.
+///
+/// Two lists are considered equal if they have the same number of elements,
+/// and the elements of one set can be paired with the elements
+/// of the other list, so that each pair are equal.
+class UnorderedListEquality<E> extends _UnorderedEquality<E, List<E>> {
+  const UnorderedListEquality(
+      [Equality<E> elementEquality = const DefaultEquality<Never>()])
+      : super(elementEquality);
+
+  @override
+  bool isValidKey(Object? o) => o is List<E>;
+}
+
 /// Equality of sets.
 ///
 /// Two sets are considered equal if they have the same number of elements,

--- a/test/equality_test.dart
+++ b/test/equality_test.dart
@@ -67,12 +67,30 @@ void main() {
         isFalse);
   });
 
-  test('UnorderedIterableInequality values', () {
+  test('UnorderedListInequality values', () {
     var list7 = [o(1), o(3), o(5), o(4), o(6)];
-    expect(const UnorderedIterableEquality().equals(list1, list7), isFalse);
-    expect(
-        const UnorderedIterableEquality(IdentityEquality())
-            .equals(list1, list7),
+    expect(const UnorderedListEquality().equals(list1, list7), isFalse);
+    expect(const UnorderedListEquality(IdentityEquality()).equals(list1, list7),
+        isFalse);
+  });
+
+  test('UnorderedListEquality', () {
+    expect(const UnorderedListEquality().equals(list1, list3), isTrue);
+    Equality uniterId = const UnorderedListEquality(IdentityEquality());
+    expect(uniterId.equals(list1, list3), isFalse);
+  });
+
+  test('UnorderedListInequality length', () {
+    var list6 = [o(1), o(3), o(5), o(4), o(2), o(1)];
+    expect(const UnorderedListEquality().equals(list1, list6), isFalse);
+    expect(const UnorderedListEquality(IdentityEquality()).equals(list1, list6),
+        isFalse);
+  });
+
+  test('UnorderedListInequality values', () {
+    var list7 = [o(1), o(3), o(5), o(4), o(6)];
+    expect(const UnorderedListEquality().equals(list1, list7), isFalse);
+    expect(const UnorderedListEquality(IdentityEquality()).equals(list1, list7),
         isFalse);
   });
 

--- a/test/equality_test.dart
+++ b/test/equality_test.dart
@@ -67,7 +67,7 @@ void main() {
         isFalse);
   });
 
-  test('UnorderedListInequality values', () {
+  test('UnorderedIterableInequality values', () {
     var list7 = [o(1), o(3), o(5), o(4), o(6)];
     expect(const UnorderedListEquality().equals(list1, list7), isFalse);
     expect(const UnorderedListEquality(IdentityEquality()).equals(list1, list7),

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1389,6 +1389,17 @@ void main() {
                 [1]
               ], const ListEquality()),
               true);
+          expect(
+              [
+                ['S1', 'S2', 'S3'],
+                ['S1', 'S2', 'S3'],
+                ['S3', 'S2', 'S1']
+              ].equals([
+                ['S1', 'S2', 'S3'],
+                ['S3', 'S2', 'S1'],
+                ['S1', 'S2', 'S3']
+              ], const UnorderedListEquality<String>()),
+              true);
         });
       });
       group('.forEachIndexed', () {


### PR DESCRIPTION
That is used to compare between 2 `List<List<T>>` without considering order.
I found it necessary if I want to use `equals` list extension method.