### PR TITLE
Move all extensions methods into their own extensions

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -8,16 +8,13 @@ import 'package:collection/src/utils.dart';
 
 import 'algorithms.dart';
 
-/// Extensions that apply to all iterables.
-///
-/// These extensions provide direct access to some of the
-/// algorithms expose by this package,
-/// as well as some generally useful convenience methods.
-///
-/// More specialized extension methods that only apply to
-/// iterables with specific element types include those of
-/// [IterableComparableExtension] and [IterableNullableExtension].
+@Deprecated('Use specialized extensions such as IterableSortedExtension')
 extension IterableExtension<T> on Iterable<T> {
+  // Do not add extension methods here.
+  // Place each extension method in its own extension.
+}
+
+extension IterableSampleExtension<T> on Iterable<T> {
   /// Selects [count] elements at random from this iterable.
   ///
   /// The returned list contains [count] different elements of the iterable.
@@ -48,16 +45,22 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return chosen;
   }
+}
 
+extension IterableWhereNotExtension<T> on Iterable<T> {
   /// The elements that do not satisfy [test].
   Iterable<T> whereNot(bool Function(T element) test) =>
       where((element) => !test(element));
+}
 
+extension IterableSortedExtension<T> on Iterable<T> {
   /// Creates a sorted list of the elements of the iterable.
   ///
   /// The elements are ordered by the [compare] [Comparator].
   List<T> sorted(Comparator<T> compare) => [...this]..sort(compare);
+}
 
+extension IterableSortedByExtension<T> on Iterable<T> {
   /// Creates a sorted list of the elements of the iterable.
   ///
   /// The elements are ordered by the natural ordering of the
@@ -67,7 +70,9 @@ extension IterableExtension<T> on Iterable<T> {
     quickSortBy<T, K>(elements, keyOf, compareComparable);
     return elements;
   }
+}
 
+extension IterableSortedByCompareExtension<T> on Iterable<T> {
   /// Creates a sorted list of the elements of the iterable.
   ///
   /// The elements are ordered by the [compare] [Comparator] of the
@@ -78,7 +83,9 @@ extension IterableExtension<T> on Iterable<T> {
     quickSortBy<T, K>(elements, keyOf, compare);
     return elements;
   }
+}
 
+extension IterableIsSortedExtension<T> on Iterable<T> {
   /// Whether the elements are sorted by the [compare] ordering.
   ///
   /// Compares pairs of elements using `compare` to check that
@@ -98,7 +105,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return true;
   }
+}
 
+extension IterableIsSortedByExtension<T> on Iterable<T> {
   /// Whether the elements are sorted by their [keyOf] property.
   ///
   /// Applies [keyOf] to each element in iteration order,
@@ -114,7 +123,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return true;
   }
+}
 
+extension IterableIsSortedByCompareExtension<T> on Iterable<T> {
   /// Whether the elements are [compare]-sorted by their [keyOf] property.
   ///
   /// Applies [keyOf] to each element in iteration order,
@@ -132,7 +143,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return true;
   }
+}
 
+extension IterableForEachIndexedExtension<T> on Iterable<T> {
   /// Takes an action for each element.
   ///
   /// Calls [action] for each element along with the index in the
@@ -143,7 +156,9 @@ extension IterableExtension<T> on Iterable<T> {
       action(index++, element);
     }
   }
+}
 
+extension IterableForEachWhileExtension<T> on Iterable<T> {
   /// Takes an action for each element as long as desired.
   ///
   /// Calls [action] for each element.
@@ -153,7 +168,9 @@ extension IterableExtension<T> on Iterable<T> {
       if (!action(element)) break;
     }
   }
+}
 
+extension IterableForEachIndexedWhileExtension<T> on Iterable<T> {
   /// Takes an action for each element and index as long as desired.
   ///
   /// Calls [action] for each element along with the index in the
@@ -165,7 +182,9 @@ extension IterableExtension<T> on Iterable<T> {
       if (!action(index++, element)) break;
     }
   }
+}
 
+extension IterableMapIndexedExtension<T> on Iterable<T> {
   /// Maps each element and its index to a new value.
   Iterable<R> mapIndexed<R>(R Function(int index, T element) convert) sync* {
     var index = 0;
@@ -173,7 +192,9 @@ extension IterableExtension<T> on Iterable<T> {
       yield convert(index++, element);
     }
   }
+}
 
+extension IterableWhereIndexedExtension<T> on Iterable<T> {
   /// The elements whose value and index satisfies [test].
   Iterable<T> whereIndexed(bool Function(int index, T element) test) sync* {
     var index = 0;
@@ -181,7 +202,9 @@ extension IterableExtension<T> on Iterable<T> {
       if (test(index++, element)) yield element;
     }
   }
+}
 
+extension IterableWhereNotIndexedExtension<T> on Iterable<T> {
   /// The elements whose value and index do not satisfy [test].
   Iterable<T> whereNotIndexed(bool Function(int index, T element) test) sync* {
     var index = 0;
@@ -189,7 +212,9 @@ extension IterableExtension<T> on Iterable<T> {
       if (!test(index++, element)) yield element;
     }
   }
+}
 
+extension IterableExpandIndexedExtension<T> on Iterable<T> {
   /// Expands each element and index to a number of elements in a new iterable.
   Iterable<R> expandIndexed<R>(
       Iterable<R> Function(int index, T element) expend) sync* {
@@ -198,7 +223,9 @@ extension IterableExtension<T> on Iterable<T> {
       yield* expend(index++, element);
     }
   }
+}
 
+extension IterableReduceIndexedExtension<T> on Iterable<T> {
   /// Combine the elements with each other and the current index.
   ///
   /// Calls [combine] for each element except the first.
@@ -221,7 +248,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableFoldIndexedExtension<T> on Iterable<T> {
   /// Combine the elements with a value and the current index.
   ///
   /// Calls [combine] for each element with the current index,
@@ -239,7 +268,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableFirstWhereOrNullExtension<T> on Iterable<T> {
   /// The first element satisfying [test], or `null` if there are none.
   T? firstWhereOrNull(bool Function(T element) test) {
     for (var element in this) {
@@ -247,7 +278,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return null;
   }
+}
 
+extension IterableFirstWhereIndexedOrNullExtension<T> on Iterable<T> {
   /// The first element whose value and index satisfies [test].
   ///
   /// Returns `null` if there are no element and index satisfying [test].
@@ -258,14 +291,18 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return null;
   }
+}
 
+extension IterableFirstOrNullExtension<T> on Iterable<T> {
   /// The first element, or `null` if the iterable is empty.
   T? get firstOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) return iterator.current;
     return null;
   }
+}
 
+extension IterableLastWhereOrNullExtension<T> on Iterable<T> {
   /// The last element satisfying [test], or `null` if there are none.
   T? lastWhereOrNull(bool Function(T element) test) {
     T? result;
@@ -274,7 +311,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableLastWhereIndexedOrNullExtension<T> on Iterable<T> {
   /// The last element whose index and value satisfies [test].
   ///
   /// Returns `null` if no element and index satisfies [test].
@@ -286,13 +325,17 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableLastOrNullExtension<T> on Iterable<T> {
   /// The last element, or `null` if the iterable is empty.
   T? get lastOrNull {
     if (isEmpty) return null;
     return last;
   }
+}
 
+extension IterableSingleWhereOrNullExtension<T> on Iterable<T> {
   /// The single element satisfying [test].
   ///
   /// Returns `null` if there are either no elements
@@ -316,7 +359,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableSingleWhereIndexedOrNullExtension<T> on Iterable<T> {
   /// The single element satisfying [test].
   ///
   /// Returns `null` if there are either none
@@ -337,7 +382,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableSingleOrNullExtension<T> on Iterable<T> {
   /// The single element of the iterable, or `null`.
   ///
   /// The value is `null` if the iterable is empty
@@ -352,7 +399,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return null;
   }
+}
 
+extension IterableGroupFoldByExtension<T> on Iterable<T> {
   /// Groups elements by [keyOf] then folds the elements in each group.
   ///
   /// A key is found for each element using [keyOf].
@@ -375,7 +424,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableGroupSetsByExtension<T> on Iterable<T> {
   /// Groups elements into sets by [keyOf].
   Map<K, Set<T>> groupSetsBy<K>(K Function(T element) keyOf) {
     var result = <K, Set<T>>{};
@@ -384,7 +435,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableGroupListsByExtension<T> on Iterable<T> {
   /// Groups elements into lists by [keyOf].
   Map<K, List<T>> groupListsBy<K>(K Function(T element) keyOf) {
     var result = <K, List<T>>{};
@@ -393,7 +446,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
+}
 
+extension IterableSplitBeforeExtension<T> on Iterable<T> {
   /// Splits the elements into chunks before some elements.
   ///
   /// Each element except the first is checked using [test]
@@ -410,7 +465,9 @@ extension IterableExtension<T> on Iterable<T> {
   /// ```
   Iterable<List<T>> splitBefore(bool Function(T element) test) =>
       splitBeforeIndexed((_, element) => test(element));
+}
 
+extension IterableSplitAfterExtension<T> on Iterable<T> {
   /// Splits the elements into chunks before some elements.
   ///
   /// Each element is checked using [test] for whether it should start a new chunk.
@@ -425,7 +482,9 @@ extension IterableExtension<T> on Iterable<T> {
   /// ```
   Iterable<List<T>> splitAfter(bool Function(T element) test) =>
       splitAfterIndexed((_, element) => test(element));
+}
 
+extension IterableSplitBetweenExtension<T> on Iterable<T> {
   /// Splits the elements into chunks between some elements.
   ///
   /// Each pair of adjacent elements are checked using [test]
@@ -441,7 +500,9 @@ extension IterableExtension<T> on Iterable<T> {
   /// ```
   Iterable<List<T>> splitBetween(bool Function(T first, T second) test) =>
       splitBetweenIndexed((_, first, second) => test(first, second));
+}
 
+extension IterableSplitBeforeIndexedExtension<T> on Iterable<T> {
   /// Splits the elements into chunks before some elements and indices.
   ///
   /// Each element and index except the first is checked using [test]
@@ -474,7 +535,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     yield chunk;
   }
+}
 
+extension IterableSplitAfterIndexedExtension<T> on Iterable<T> {
   /// Splits the elements into chunks after some elements and indices.
   ///
   /// Each element and index is checked using [test]
@@ -502,7 +565,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     if (chunk != null) yield chunk;
   }
+}
 
+extension IterableSplitBetweenIndexedExtension<T> on Iterable<T> {
   /// Splits the elements into chunks between some elements and indices.
   ///
   /// Each pair of adjacent elements and the index of the latter are
@@ -535,7 +600,9 @@ extension IterableExtension<T> on Iterable<T> {
     }
     yield chunk;
   }
+}
 
+extension IterableNoneExtension<T> on Iterable<T> {
   /// Whether no element satisfies [test].
   ///
   /// Returns true if no element satisfies [test],
@@ -551,8 +618,7 @@ extension IterableExtension<T> on Iterable<T> {
   }
 }
 
-/// Extensions that apply to iterables with a nullable element type.
-extension IterableNullableExtension<T extends Object> on Iterable<T?> {
+extension IterableWhereNotNullExtension<T extends Object> on Iterable<T?> {
   /// The non-`null` elements of this `Iterable`.
   ///
   /// Returns an iterable which emits all the non-`null` elements
@@ -566,8 +632,7 @@ extension IterableNullableExtension<T extends Object> on Iterable<T?> {
   }
 }
 
-/// Extensions that apply to iterables of numbers.
-extension IterableNumberExtension on Iterable<num> {
+extension IterableSumNumberExtension on Iterable<num> {
   /// The sum of the elements.
   ///
   /// The sum is zero if the iterable is empty.
@@ -578,7 +643,9 @@ extension IterableNumberExtension on Iterable<num> {
     }
     return result;
   }
+}
 
+extension IterableAverageNumberExtension<T> on Iterable<num> {
   /// The arithmetic mean of the elements of a non-empty iterable.
   ///
   /// The arithmetic mean is the sum of the elements
@@ -597,10 +664,7 @@ extension IterableNumberExtension on Iterable<num> {
   }
 }
 
-/// Extension on iterables of integers.
-///
-/// Specialized version of some extensions of [IterableNumberExtension].
-extension IterableIntegerExtension on Iterable<int> {
+extension IterableSumIntegerExtension on Iterable<int> {
   /// The sum of the elements.
   ///
   /// The sum is zero if the iterable is empty.
@@ -611,7 +675,9 @@ extension IterableIntegerExtension on Iterable<int> {
     }
     return result;
   }
+}
 
+extension IterableAverageIntegerExtension<T> on Iterable<int> {
   /// The arithmetic mean of the elements of a non-empty iterable.
   ///
   /// The arithmetic mean is the sum of the elements
@@ -639,10 +705,7 @@ extension IterableIntegerExtension on Iterable<int> {
   }
 }
 
-/// Extension on iterables of double.
-///
-/// Specialized version of some extensions of [IterableNumberExtension].
-extension IterableDoubleExtension on Iterable<double> {
+extension IterableSumDoubleExtension on Iterable<double> {
   /// The sum of the elements.
   ///
   /// The sum is zero if the iterable is empty.
@@ -655,8 +718,7 @@ extension IterableDoubleExtension on Iterable<double> {
   }
 }
 
-/// Extensions on iterables whose elements are also iterables.
-extension IterableIterableExtension<T> on Iterable<Iterable<T>> {
+extension IterableFlattenedExtension<T> on Iterable<Iterable<T>> {
   /// The sequential elements of each iterable in this iterable.
   ///
   /// Iterates the elements of this iterable.
@@ -670,12 +732,8 @@ extension IterableIterableExtension<T> on Iterable<Iterable<T>> {
   }
 }
 
-/// Extensions that apply to iterables of [Comparable] elements.
-///
-/// These operations can assume that the elements have a natural ordering,
-/// and can therefore omit, or make it optional, for the user to provide
-/// a [Comparator].
-extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
+extension IterableMinOrNullComparableExtension<T extends Comparable<T>>
+    on Iterable<T> {
   /// A minimal element of the iterable, or `null` it the iterable is empty.
   T? get minOrNull {
     var iterator = this.iterator;
@@ -691,7 +749,10 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
     }
     return null;
   }
+}
 
+extension IterableMinComparableExtension<T extends Comparable<T>>
+    on Iterable<T> {
   /// A minimal element of the iterable.
   ///
   /// The iterable must not be empty.
@@ -709,7 +770,10 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
     }
     throw StateError('No element');
   }
+}
 
+extension IterableMaxOrNullComparableExtension<T extends Comparable<T>>
+    on Iterable<T> {
   /// A maximal element of the iterable, or `null` if the iterable is empty.
   T? get maxOrNull {
     var iterator = this.iterator;
@@ -725,7 +789,10 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
     }
     return null;
   }
+}
 
+extension IterableMaxComparableExtension<T extends Comparable<T>>
+    on Iterable<T> {
   /// A maximal element of the iterable.
   ///
   /// The iterable must not be empty.
@@ -743,20 +810,26 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
     }
     throw StateError('No element');
   }
+}
 
+extension IterableSortedComparableExtension<T extends Comparable<T>>
+    on Iterable<T> {
   /// Creates a sorted list of the elements of the iterable.
   ///
   /// If the [compare] function is not supplied, the sorting uses the
   /// natural [Comparable] ordering of the elements.
   List<T> sorted([Comparator<T>? compare]) => [...this]..sort(compare);
+}
 
+extension IterableIsSortedComparableExtension<T extends Comparable<T>>
+    on Iterable<T> {
   /// Whether the elements are sorted by the [compare] ordering.
   ///
   /// If [compare] is omitted, it defaults to comparing the
   /// elements using their natural [Comparable] ordering.
   bool isSorted([Comparator<T>? compare]) {
     if (compare != null) {
-      return IterableExtension(this).isSorted(compare);
+      return IterableIsSortedExtension(this).isSorted(compare);
     }
     var iterator = this.iterator;
     if (!iterator.moveNext()) return true;
@@ -770,18 +843,21 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
   }
 }
 
-/// Extensions on comparator functions.
-extension ComparatorExtension<T> on Comparator<T> {
+extension ComparatorInverseExtension<T> on Comparator<T> {
   /// The inverse ordering of this comparator.
   Comparator<T> get inverse => (T a, T b) => this(b, a);
+}
 
+extension ComparatorCompareByExtension<T> on Comparator<T> {
   /// Makes a comparator on [R] values using this comparator.
   ///
   /// Compares [R] values by comparing their [keyOf] value
   /// using this comparator.
   Comparator<R> compareBy<R>(T Function(R) keyOf) =>
       (R a, R b) => this(keyOf(a), keyOf(b));
+}
 
+extension ComparatorThenExtension<T> on Comparator<T> {
   /// Combine comparators sequentially.
   ///
   /// Creates a comparator which orders elements the same way as

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -11,8 +11,13 @@ import 'algorithms.dart' as algorithms;
 import 'equality.dart';
 import 'utils.dart';
 
-/// Various extensions on lists of arbitrary elements.
-extension ListExtensions<E> on List<E> {
+@Deprecated('Use specialized extensions such as ListBinarySearchExtension')
+extension ListExtension<E> on List<E> {
+  // Do not add extension methods here.
+  // Place each extension method in its own extension.
+}
+
+extension ListBinarySearchExtension<E> on List<E> {
   /// Returns the index of [element] in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -22,7 +27,9 @@ extension ListExtensions<E> on List<E> {
   /// Returns -1 if [element] does not occur in this list.
   int binarySearch(E element, int Function(E, E) compare) =>
       algorithms.binarySearchBy<E, E>(this, identity, compare, element);
+}
 
+extension ListBinarySearchByCompareExtension<E> on List<E> {
   /// Returns the index of [element] in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -38,7 +45,9 @@ extension ListExtensions<E> on List<E> {
           [int start = 0, int? end]) =>
       algorithms.binarySearchBy<E, K>(
           this, keyOf, compare, element, start, end);
+}
 
+extension ListBinarySearchByExtension<E> on List<E> {
   /// Returns the index of [element] in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -53,7 +62,9 @@ extension ListExtensions<E> on List<E> {
           E element, K Function(E element) keyOf, [int start = 0, int? end]) =>
       algorithms.binarySearchBy<E, K>(
           this, keyOf, (a, b) => a.compareTo(b), element, start, end);
+}
 
+extension ListLowerBoundExtension<E> on List<E> {
   /// Returns the index where [element] should be in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -67,7 +78,9 @@ extension ListExtensions<E> on List<E> {
   /// [element].
   int lowerBound(E element, int Function(E, E) compare) =>
       algorithms.lowerBoundBy<E, E>(this, identity, compare, element);
+}
 
+extension ListLowerBoundByCompareExtension<E> on List<E> {
   /// Returns the index where [element] should be in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -86,7 +99,9 @@ extension ListExtensions<E> on List<E> {
           E element, K Function(E) keyOf, int Function(K, K) compare,
           [int start = 0, int? end]) =>
       algorithms.lowerBoundBy(this, keyOf, compare, element, start, end);
+}
 
+extension ListLowerBoundByExtension<E> on List<E> {
   /// Returns the index where [element] should be in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -106,7 +121,9 @@ extension ListExtensions<E> on List<E> {
           [int start = 0, int? end]) =>
       algorithms.lowerBoundBy<E, K>(
           this, keyOf, compareComparable, element, start, end);
+}
 
+extension ListForEachIndexedExtension<E> on List<E> {
   /// Takes an action for each element.
   ///
   /// Calls [action] for each element along with the index in the
@@ -116,7 +133,9 @@ extension ListExtensions<E> on List<E> {
       action(index, this[index]);
     }
   }
+}
 
+extension ListForEachWhileExtension<E> on List<E> {
   /// Takes an action for each element as long as desired.
   ///
   /// Calls [action] for each element.
@@ -126,7 +145,9 @@ extension ListExtensions<E> on List<E> {
       if (!action(this[index])) break;
     }
   }
+}
 
+extension ListForEachIndexedWhileExtension<E> on List<E> {
   /// Takes an action for each element and index as long as desired.
   ///
   /// Calls [action] for each element along with the index in the
@@ -137,14 +158,18 @@ extension ListExtensions<E> on List<E> {
       if (!action(index, this[index])) break;
     }
   }
+}
 
+extension ListMapIndexedExtension<E> on List<E> {
   /// Maps each element and its index to a new value.
   Iterable<R> mapIndexed<R>(R Function(int index, E element) convert) sync* {
     for (var index = 0; index < length; index++) {
       yield convert(index, this[index]);
     }
   }
+}
 
+extension ListWhereIndexedExtension<E> on List<E> {
   /// The elements whose value and index satisfies [test].
   Iterable<E> whereIndexed(bool Function(int index, E element) test) sync* {
     for (var index = 0; index < length; index++) {
@@ -152,7 +177,9 @@ extension ListExtensions<E> on List<E> {
       if (test(index, element)) yield element;
     }
   }
+}
 
+extension ListWhereNotIndexedExtension<E> on List<E> {
   /// The elements whose value and index do not satisfy [test].
   Iterable<E> whereNotIndexed(bool Function(int index, E element) test) sync* {
     for (var index = 0; index < length; index++) {
@@ -160,7 +187,9 @@ extension ListExtensions<E> on List<E> {
       if (!test(index, element)) yield element;
     }
   }
+}
 
+extension ListExpandedIndexedExtension<E> on List<E> {
   /// Expands each element and index to a number of elements in a new iterable.
   ///
   /// Like [Iterable.expand] except that the callback function is supplied with
@@ -171,12 +200,16 @@ extension ListExtensions<E> on List<E> {
       yield* expand(index, this[index]);
     }
   }
+}
 
+extension ListSortRangeExtension<E> on List<E> {
   /// Sort a range of elements by [compare].
   void sortRange(int start, int end, int Function(E a, E b) compare) {
     quickSortBy<E, E>(this, identity, compare, start, end);
   }
+}
 
+extension ListSortByCompareExtension<E> on List<E> {
   /// Sorts elements by the [compare] of their [keyOf] property.
   ///
   /// Sorts elements from [start] to [end], defaulting to the entire list.
@@ -185,7 +218,9 @@ extension ListExtensions<E> on List<E> {
       [int start = 0, int? end]) {
     quickSortBy(this, keyOf, compare, start, end);
   }
+}
 
+extension ListSortByExtension<E> on List<E> {
   /// Sorts elements by the natural order of their [keyOf] property.
   ///
   /// Sorts elements from [start] to [end], defaulting to the entire list.
@@ -193,13 +228,17 @@ extension ListExtensions<E> on List<E> {
       [int start = 0, int? end]) {
     quickSortBy<E, K>(this, keyOf, compareComparable, start, end);
   }
+}
 
+extension ListShuffleRangeExtension<E> on List<E> {
   /// Shuffle a range of elements.
   void shuffleRange(int start, int end, [Random? random]) {
     RangeError.checkValidRange(start, end, length);
     shuffle(this, start, end, random);
   }
+}
 
+extension ListReverseRangeExtension<E> on List<E> {
   /// Reverses the elements in a range of the list.
   void reverseRange(int start, int end) {
     RangeError.checkValidRange(start, end, length);
@@ -210,7 +249,9 @@ extension ListExtensions<E> on List<E> {
       start += 1;
     }
   }
+}
 
+extension ListSwapExtension<E> on List<E> {
   /// Swaps two elements of this list.
   void swap(int index1, int index2) {
     RangeError.checkValidIndex(index1, this, 'index1');
@@ -219,7 +260,9 @@ extension ListExtensions<E> on List<E> {
     this[index1] = this[index2];
     this[index2] = tmp;
   }
+}
 
+extension ListSliceExtension<E> on List<E> {
   /// A fixed length view of a range of this list.
   ///
   /// The view is backed by this this list, which must not
@@ -238,7 +281,9 @@ extension ListExtensions<E> on List<E> {
     if (self is ListSlice) return self.slice(start, end);
     return ListSlice<E>(this, start, end);
   }
+}
 
+extension ListEqualsExtension<E> on List<E> {
   /// Whether [other] has the same elements as this list.
   ///
   /// Returns true iff [other] has the same [length]
@@ -254,8 +299,15 @@ extension ListExtensions<E> on List<E> {
   }
 }
 
-/// Various extensions on lists of comparable elements.
+@Deprecated(
+    'Use specialized extensions such as ListBinarySearchComparableExtension')
 extension ListComparableExtensions<E extends Comparable<E>> on List<E> {
+  // Do not add extension methods here.
+  // Place each extension method in its own extension.
+}
+
+extension ListBinarySearchComparableExtension<E extends Comparable<E>>
+    on List<E> {
   /// Returns the index of [element] in this sorted list.
   ///
   /// Uses binary search to find the location of [element].
@@ -267,7 +319,10 @@ extension ListComparableExtensions<E extends Comparable<E>> on List<E> {
   int binarySearch(E element, [int Function(E, E)? compare]) =>
       algorithms.binarySearchBy<E, E>(
           this, identity, compare ?? compareComparable, element);
+}
 
+extension ListLowerBoundComparableExtension<E extends Comparable<E>>
+    on List<E> {
   /// Returns the index where [element] should be in this sorted list.
   ///
   /// Uses binary search to find the location of where [element] should be.
@@ -281,7 +336,9 @@ extension ListComparableExtensions<E extends Comparable<E>> on List<E> {
   int lowerBound(E element, [int Function(E, E)? compare]) =>
       algorithms.lowerBoundBy<E, E>(
           this, identity, compare ?? compareComparable, element);
+}
 
+extension ListSortRangeComparableExtension<E extends Comparable<E>> on List<E> {
   /// Sort a range of elements by [compare].
   ///
   /// If [compare] is omitted, the range is sorted according to the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.15.0
+version: 1.16.0
 
 description: Collections and utilities functions and classes related to collections.
 homepage: https://github.com/dart-lang/collection

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('mapMap()', () {
     test('with an empty map returns an empty map', () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
+          // ignore: deprecated_member_use_from_same_package, deprecated_member_use
           mapMap({},
               key: expectAsync2((_, __) {}, count: 0),
               value: expectAsync2((_, __) {}, count: 0)),
@@ -19,7 +19,7 @@ void main() {
 
     test('with no callbacks, returns a copy of the map', () {
       var map = {'foo': 1, 'bar': 2};
-      // ignore: deprecated_member_use_from_same_package
+      // ignore: deprecated_member_use_from_same_package, deprecated_member_use
       var result = mapMap(map);
       expect(result, equals({'foo': 1, 'bar': 2}));
 
@@ -30,7 +30,7 @@ void main() {
 
     test("maps the map's keys", () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
+          // ignore: deprecated_member_use_from_same_package, deprecated_member_use
           mapMap({'foo': 1, 'bar': 2},
               key: (dynamic key, dynamic value) => key[value]),
           equals({'o': 1, 'r': 2}));
@@ -38,7 +38,7 @@ void main() {
 
     test("maps the map's values", () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
+          // ignore: deprecated_member_use_from_same_package, deprecated_member_use
           mapMap({'foo': 1, 'bar': 2},
               value: (dynamic key, dynamic value) => key[value]),
           equals({'foo': 'o', 'bar': 'r'}));
@@ -46,7 +46,7 @@ void main() {
 
     test("maps both the map's keys and values", () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
+          // ignore: deprecated_member_use_from_same_package, deprecated_member_use
           mapMap({'foo': 1, 'bar': 2},
               key: (dynamic key, dynamic value) => '$key$value',
               value: (dynamic key, dynamic value) => key[value]),


### PR DESCRIPTION
This allows the usage of show/hide to resolve naming conflicts with other libraries

Allows the usage of `package:dartx` and `package:collection` in a single dart file with `show`/`hide`

Fixes #183 