### PR TITLE
Use a stable sort algorithm for Iterable.sortedBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.15.1-dev
+## 1.16.0
+
+* Use a stable sort algorithm in the `IterableExtension.sortedBy` method.
 
 ## 1.15.0
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -64,7 +64,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// property [keyOf] of the element.
   List<T> sortedBy<K extends Comparable<K>>(K Function(T element) keyOf) {
     var elements = [...this];
-    quickSortBy<T, K>(elements, keyOf, compareComparable);
+    mergeSortBy<T, K>(elements, keyOf, compareComparable);
     return elements;
   }
 
@@ -75,7 +75,7 @@ extension IterableExtension<T> on Iterable<T> {
   List<T> sortedByCompare<K>(
       K Function(T element) keyOf, Comparator<K> compare) {
     var elements = [...this];
-    quickSortBy<T, K>(elements, keyOf, compare);
+    mergeSortBy<T, K>(elements, keyOf, compare);
     return elements;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.15.1-dev
+version: 1.16.0
 
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection


### PR DESCRIPTION
The random nature of the quick sort algorithm is surprising for an extension like `sortedBy`.

For reference, C# uses a stable sort for [`Enumerable.OrderBy`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.orderby?redirectedfrom=MSDN&view=net-5.0#System_Linq_Enumerable_OrderBy__2_System_Collections_Generic_IEnumerable___0__System_Func___0___1__)