### PR TITLE
Fix new unused import diagnostic

### DIFF
--- a/lib/src/empty_unmodifiable_set.dart
+++ b/lib/src/empty_unmodifiable_set.dart
@@ -6,8 +6,6 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart';
 
-import 'unmodifiable_wrappers.dart';
-
 /// An unmodifiable, empty set which can be constant.
 class EmptyUnmodifiableSet<E> extends IterableBase<E>
     with UnmodifiableSetMixin<E>


### PR DESCRIPTION
The check is now stronger and surfaces imports that are only exposing
symbols that are also available through other imports.