### PR TITLE
Add seperatedBy and toMap extensions.

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -589,6 +589,19 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return true;
   }
+
+  /// The elements with [seperator] between each.
+  Iterable<T> seperatedBy(T seperator) sync* {
+    if (isEmpty) return;
+
+    final iterator = this.iterator;
+    iterator.moveNext();
+    yield iterator.current;
+    while (iterator.moveNext()) {
+      yield seperator;
+      yield iterator.current;
+    }
+  }
 }
 
 /// Extensions that apply to iterables with a nullable element type.
@@ -832,4 +845,9 @@ extension ComparatorExtension<T> on Comparator<T> {
         if (result == 0) result = tieBreaker(a, b);
         return result;
       };
+}
+
+extension MapEntryExtension<K, V> on Iterable<MapEntry<K, V>> {
+  /// Creates a map from [Iterable<MapEntry>].
+  Map<K, V> toMap() => Map.fromEntries(this);
 }


### PR DESCRIPTION
Adds `seperatedBy` and `toMap` extensions.

These were extensions I was using in my own projects and thought I'd contribute.

`seperatedBy` example
```dart
return Column(children: list.map((e) => ListTile(title: Text(e)).seperatedBy(const Divider()).toList());
```

`toMap` example
```dart
return list.mapIndexed((index, e) => MapEntry(index, e)).toMap();
```