### PR TITLE
Add Iterable.elementAtOrNull extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.16.1-dev
+## 1.17.0-dev
+
+* Add `Iterable.elementAtOrNull` and `List.elementAtOrNull` extension methods.
 
 ## 1.16.0
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -352,10 +352,16 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return null;
   }
-  
-  /// Returns an element at the given [index]
-  /// or `null` if the [index] is out of bounds of this list.
-  /// [index] must not be negative
+
+  /// The [index]th element, or `null` if there is no such element.
+  ///
+  /// Returns the element at position [index] of this iterable,
+  /// just like [elementAt], if this iterable has such an element.
+  /// If this iterable does not have enough elements to have one with the given
+  /// [index], the `null` value is returned, unlike [elementAt] which throws
+  /// instead.
+  ///
+  /// The [index] must not be negative.
   T? elementAtOrNull(int index) => skip(index).firstOrNull;
 
   /// Groups elements by [keyOf] then folds the elements in each group.

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -352,6 +352,11 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return null;
   }
+  
+  /// Returns an element at the given [index]
+  /// or `null` if the [index] is out of bounds of this list.
+  /// [index] must not be negative
+  T? elementAtOrNull(int index) => skip(index).firstOrNull;
 
   /// Groups elements by [keyOf] then folds the elements in each group.
   ///

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -258,10 +258,17 @@ extension ListExtensions<E> on List<E> {
     }
     return true;
   }
-  /// Returns an element at the given [index]
-  /// or `null` if the [index] is out of bounds of this list.
-  /// [index] must not be negative
-  T? elementAtOrNull(int index) => (index < length) ? this[index] : null;
+
+  /// The [index]th element, or `null` if there is no such element.
+  ///
+  /// Returns the element at position [index] of this list,
+  /// just like [elementAt], if this list has such an element.
+  /// If this list does not have enough elements to have one with the given
+  /// [index], the `null` value is returned, unlike [elementAt] which throws
+  /// instead.
+  ///
+  /// The [index] must not be negative.
+  E? elementAtOrNull(int index) => (index < length) ? this[index] : null;
 
   /// Contiguous [slice]s of [this] with the given [length].
   ///

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -255,7 +255,8 @@ extension ListExtensions<E> on List<E> {
   
   /// Returns an element at the given [index]
   /// or `null` if the [index] is out of bounds of this list.
-  E? getOrNull(int index) => (index >= 0 && index < length) ? this[index] : null;
+  /// [index] must not be negative
+  T? elementAtOrNull(int index) => (index < length) ? this[index] : null;
 }
 
 /// Various extensions on lists of comparable elements.

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -252,6 +252,10 @@ extension ListExtensions<E> on List<E> {
     }
     return true;
   }
+  
+  /// Returns an element at the given [index]
+  /// or `null` if the [index] is out of bounds of this list.
+  E? getOrNull(int index) => (index >= 0 && index < length) ? this[index] : null;
 }
 
 /// Various extensions on lists of comparable elements.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.16.1-dev
+version: 1.17.0-dev
 
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1141,6 +1141,21 @@ void main() {
         }
       });
     });
+    group('.elementAtOrNull', () {
+      test('empty', () async {
+        expect(iterable([]).elementAtOrNull(0), isNull);
+      });
+      test('negative index', () async {
+        expect(() => iterable([1]).elementAtOrNull(-1),
+            throwsA(isA<RangeError>()));
+      });
+      test('index within range', () async {
+        expect(iterable([1]).elementAtOrNull(0), 1);
+      });
+      test('index too high', () async {
+        expect(iterable([1]).elementAtOrNull(1), isNull);
+      });
+    });
     group('.slices', () {
       test('empty', () {
         expect(iterable(<int>[]).slices(1), []);
@@ -1727,6 +1742,20 @@ void main() {
         test('varying result', () {
           expect(['a', 'b'].expandIndexed((i, v) => i.isOdd ? ['$i', v] : []),
               ['1', 'b']);
+        });
+      });
+      group('.elementAtOrNull', () {
+        test('empty', () async {
+          expect([].elementAtOrNull(0), isNull);
+        });
+        test('negative index', () async {
+          expect(() => [1].elementAtOrNull(-1), throwsA(isA<RangeError>()));
+        });
+        test('index within range', () async {
+          expect([1].elementAtOrNull(0), 1);
+        });
+        test('index too high', () async {
+          expect([1].elementAtOrNull(1), isNull);
         });
       });
       group('.slices', () {


### PR DESCRIPTION
Add a extension function for List `getOrNull(int index)`
returns a element at the given [index] of this list, if [index] out of bounds, return `null`

Example:
```dart
final list = [1,2,3];
list.getOrNull(1); // 2
list.getOrNull(10); // null
```