### PR TITLE
Remove some unnecessary `return null;`

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -590,7 +590,6 @@ extension IterableNumberExtension on Iterable<num> {
       }
       return value;
     }
-    return null;
   }
 
   /// A minimal element of the iterable.
@@ -617,7 +616,6 @@ extension IterableNumberExtension on Iterable<num> {
       }
       return value;
     }
-    return null;
   }
 
   /// A maximal element of the iterable.
@@ -672,7 +670,6 @@ extension IterableIntegerExtension on Iterable<int> {
       }
       return value;
     }
-    return null;
   }
 
   /// A minimal element of the iterable.
@@ -693,7 +690,6 @@ extension IterableIntegerExtension on Iterable<int> {
       }
       return value;
     }
-    return null;
   }
 
   /// A maximal element of the iterable.
@@ -763,7 +759,6 @@ extension IterableDoubleExtension on Iterable<double> {
       }
       return value;
     }
-    return null;
   }
 
   /// A minimal element of the iterable.
@@ -790,7 +785,6 @@ extension IterableDoubleExtension on Iterable<double> {
       }
       return value;
     }
-    return null;
   }
 
   /// A maximal element of the iterable.
@@ -864,7 +858,6 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
       }
       return value;
     }
-    return null;
   }
 
   /// A maximal element of the iterable.


### PR DESCRIPTION
There is an implicit null return at the end of the method. With null
safety it's less critical to be explicit about the null return since the
return type makes it clear.

This is the same refactoring as was made in one instance of the pattern
in
https://github.com/dart-lang/collection/pull/212/files#diff-013b70bbf26f849f2a314b4b36ec2d37374b4c8a3e21d1fb5b3d1df9788996d2L692