### PR TITLE
Restore an explicit null return

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -844,6 +844,7 @@ extension IterableComparableExtension<T extends Comparable<T>> on Iterable<T> {
       }
       return value;
     }
+    return null;
   }
 
   /// A minimal element of the iterable.


### PR DESCRIPTION
This was unnecessarily removed in an unrelated change.

https://github.com/dart-lang/collection/pull/218#discussion_r712148802