### PR TITLE
Remove unnecessary severity changes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,4 @@
 include: package:lints/recommended.yaml
-analyzer:
-  errors:
-    unused_element: error
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
 linter:
   rules:
     # Errors


### PR DESCRIPTION
These had been put in when there were specific warnings treated as fatal
in google3. Since we now treat infos as fatal its not necessary to
change the severity of individual warnings.