### PR TITLE
enable the avoid_dynamic_calls lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   Assignment to `Equality` with a nullable type is still allowed because of
   covariance. The `equals` and `hash` methods continue to accept nullable
   arguments.
-
+* Enable the `avoid_dynamic_calls` lint.
 
 ## 1.15.0
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,9 @@
 include: package:lints/recommended.yaml
+
 linter:
   rules:
+    - avoid_dynamic_calls
+
     # Errors
     - test_types_in_equals
     - throw_in_finally

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -212,7 +212,7 @@ abstract class _UnorderedEquality<E, T extends Iterable<E>>
   bool equals(T? elements1, T? elements2) {
     if (identical(elements1, elements2)) return true;
     if (elements1 == null || elements2 == null) return false;
-    var counts = HashMap<E, int?>(
+    var counts = HashMap<E, int>(
         equals: _elementEquality.equals,
         hashCode: _elementEquality.hash,
         isValidKey: _elementEquality.isValidKey);

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -212,7 +212,7 @@ abstract class _UnorderedEquality<E, T extends Iterable<E>>
   bool equals(T? elements1, T? elements2) {
     if (identical(elements1, elements2)) return true;
     if (elements1 == null || elements2 == null) return false;
-    var counts = HashMap(
+    var counts = HashMap<E, int?>(
         equals: _elementEquality.equals,
         hashCode: _elementEquality.hash,
         isValidKey: _elementEquality.isValidKey);

--- a/test/analysis_options.yaml
+++ b/test/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../analysis_options.yaml
+
+# Turn off the avoid_dynamic_calls lint for the test/ directory.
+analyzer:
+  errors:
+    avoid_dynamic_calls: ignore


### PR DESCRIPTION
- enable the `avoid_dynamic_calls` lint
- ignore the lint for the test/ directory (there are a fair number of dynamic calls here)
- address the 2 lint issues found - in lib/src/equality.dart (some computations on `int`s being added to a map)
