### PR TITLE
Add a comment about NaN in min/max extensions

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -593,7 +593,7 @@ extension IterableNullableExtension<T extends Object> on Iterable<T?> {
 extension IterableNumberExtension on Iterable<num> {
   /// A minimal element of the iterable, or `null` it the iterable is empty.
   ///
-  /// If an element is NaN, it is considered to be a minimal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   num? get minOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -617,14 +617,14 @@ extension IterableNumberExtension on Iterable<num> {
 
   /// A minimal element of the iterable.
   ///
-  /// If an element is NaN, it is considered to be a minimal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   ///
   /// The iterable must not be empty.
   num get min => minOrNull ?? (throw StateError('No element'));
 
   /// A maximal element of the iterable, or `null` if the iterable is empty.
   ///
-  /// If an element is NaN, it is considered to be a maximal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   num? get maxOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -648,7 +648,7 @@ extension IterableNumberExtension on Iterable<num> {
 
   /// A maximal element of the iterable.
   ///
-  /// If an element is NaN, it is considered to be a maximal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   ///
   /// The iterable must not be empty.
   num get max => maxOrNull ?? (throw StateError('No element'));
@@ -774,7 +774,7 @@ extension IterableIntegerExtension on Iterable<int> {
 extension IterableDoubleExtension on Iterable<double> {
   /// A minimal element of the iterable, or `null` it the iterable is empty.
   ///
-  /// If an element is NaN, it is considered to be a minimal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   double? get minOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -798,14 +798,14 @@ extension IterableDoubleExtension on Iterable<double> {
 
   /// A minimal element of the iterable.
   ///
-  /// If an element is NaN, it is considered to be a minimal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   ///
   /// The iterable must not be empty.
   double get min => minOrNull ?? (throw StateError('No element'));
 
   /// A maximal element of the iterable, or `null` if the iterable is empty.
   ///
-  /// If an element is NaN, it is considered to be a maximal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   double? get maxOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -829,7 +829,7 @@ extension IterableDoubleExtension on Iterable<double> {
 
   /// A maximal element of the iterable.
   ///
-  /// If an element is NaN, it is considered to be a maximal element.
+  /// If any element is [NaN](double.nan), the result is NaN.
   ///
   /// The iterable must not be empty.
   double get max => maxOrNull ?? (throw StateError('No element'));

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -592,6 +592,8 @@ extension IterableNullableExtension<T extends Object> on Iterable<T?> {
 /// since doubles require special handling of [double.nan].
 extension IterableNumberExtension on Iterable<num> {
   /// A minimal element of the iterable, or `null` it the iterable is empty.
+  ///
+  /// If an element is NaN, it is considered to be a minimal element.
   num? get minOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -615,10 +617,14 @@ extension IterableNumberExtension on Iterable<num> {
 
   /// A minimal element of the iterable.
   ///
+  /// If an element is NaN, it is considered to be a minimal element.
+  ///
   /// The iterable must not be empty.
   num get min => minOrNull ?? (throw StateError('No element'));
 
   /// A maximal element of the iterable, or `null` if the iterable is empty.
+  ///
+  /// If an element is NaN, it is considered to be a maximal element.
   num? get maxOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -641,6 +647,8 @@ extension IterableNumberExtension on Iterable<num> {
   }
 
   /// A maximal element of the iterable.
+  ///
+  /// If an element is NaN, it is considered to be a maximal element.
   ///
   /// The iterable must not be empty.
   num get max => maxOrNull ?? (throw StateError('No element'));
@@ -765,6 +773,8 @@ extension IterableIntegerExtension on Iterable<int> {
 /// [IterableComparableExtension] since doubles are only `Comparable<num>`.
 extension IterableDoubleExtension on Iterable<double> {
   /// A minimal element of the iterable, or `null` it the iterable is empty.
+  ///
+  /// If an element is NaN, it is considered to be a minimal element.
   double? get minOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -788,10 +798,14 @@ extension IterableDoubleExtension on Iterable<double> {
 
   /// A minimal element of the iterable.
   ///
+  /// If an element is NaN, it is considered to be a minimal element.
+  ///
   /// The iterable must not be empty.
   double get min => minOrNull ?? (throw StateError('No element'));
 
   /// A maximal element of the iterable, or `null` if the iterable is empty.
+  ///
+  /// If an element is NaN, it is considered to be a maximal element.
   double? get maxOrNull {
     var iterator = this.iterator;
     if (iterator.moveNext()) {
@@ -814,6 +828,8 @@ extension IterableDoubleExtension on Iterable<double> {
   }
 
   /// A maximal element of the iterable.
+  ///
+  /// If an element is NaN, it is considered to be a maximal element.
   ///
   /// The iterable must not be empty.
   double get max => maxOrNull ?? (throw StateError('No element'));


### PR DESCRIPTION
I noticed that NaN will be both min and max, which might be confusing to the user if not documented.

I do think returning NaNs **is better** approach than the other 2 alternatives I can think of:

- Ignoring them, which will not let user know they have NaNs in the iterable.
- Relying on `false` from comparisons to NaN, which will lead to inconsistent returns depending on NaN's placement (e.g. first or not first) in the iterable.