### PR TITLE
Added replaceWhere method in IterableExtensions

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -569,6 +569,25 @@ extension IterableExtension<T> on Iterable<T> {
       yield slice;
     }
   }
+
+  /// Creates a copy of an iterable where all values matching a given predicate
+  /// are replaced with the given value
+  ///
+  /// Example:
+  /// ```dart
+  /// final List<int> _intList  = [1, 2, 3, 4, 5];
+  /// print(_intList.replaceWhere(predicate: (value) => value <= 2, value: 0)); // (0, 0, 3, 4, 5)
+  /// ```
+  Iterable<T> replaceWhere(
+      {required bool Function(T) predicate, required T value}) sync* {
+    for (final element in this) {
+      if (!predicate(element)) {
+        yield element;
+        continue;
+      }
+      yield value;
+    }
+  }
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1176,6 +1176,32 @@ void main() {
     });
   });
 
+  group('.replaceWhere', () {
+    test('empty', () {
+      expect(
+          iterable(<int>[]).replaceWhere(predicate: (value) => true, value: 0),
+          []);
+    });
+    test('with at least one element matching the predicate', () {
+      expect(
+          iterable([1, 2, 3])
+              .replaceWhere(predicate: (value) => value == 1, value: 0),
+          [0, 2, 3]);
+    });
+    test('with one element matching the predicate', () {
+      expect(
+          iterable([1, 2, 3])
+              .replaceWhere(predicate: (value) => false, value: 0),
+          [1, 2, 3]);
+    });
+    test('with more than one element matching the predicate', () {
+      expect(
+          iterable([1, 2, 3, 4, 5])
+              .replaceWhere(predicate: (value) => value <= 2, value: 0),
+          [0, 0, 3, 4, 5]);
+    });
+  });
+
   group('Comparator', () {
     test('.inverse', () {
       var cmpStringInv = cmpString.inverse;


### PR DESCRIPTION
Added the replaceWhere method to IterableExtensions.
This method returns a copy of the Iterable where all values matching a given predicate are replaced with the given one.

Example: 
```dart
final List<int> samples  = [1, 2, 3, 4, 5];
print(samples.replaceWhere(predicate: (value) => value <= 2, value: 0)); // Output: (0, 0, 3, 4, 5)
````