### PR TITLE
Update `mergeMaps` making it more flexible

### DIFF
--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -30,14 +30,34 @@ Map<K2, V2> mapMap<K1, V1, K2, V2>(Map<K1, V1> map,
 /// select the value that goes into the resulting map based on the two original
 /// values. If [value] is omitted, the value from [map2] is used.
 Map<K, V> mergeMaps<K, V>(Map<K, V> map1, Map<K, V> map2,
-    {V Function(V, V)? value}) {
+    {V? Function(V, V)? value, bool removeDifference = false}) {
   var result = Map<K, V>.of(map1);
   if (value == null) return result..addAll(map2);
 
   map2.forEach((key, mapValue) {
-    result[key] =
-        result.containsKey(key) ? value(result[key] as V, mapValue) : mapValue;
+    if (result.containsKey(key)) {
+      final newValue = value(result[key] as V, mapValue);
+      if (newValue != null) {
+        result[key] = newValue;
+      } else {
+        result.remove(key);
+      }
+    } else {
+      result[key] = mapValue;
+    }
   });
+
+  if (removeDifference) {
+    final removedKeys = <K>[];
+    result.forEach((key, value) {
+      if (!map2.containsKey(key)) {
+        removedKeys.add(key);
+      }
+    });
+
+    result.removeWhere((key, value) => removedKeys.contains(key));
+  }
+
   return result;
 }
 

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -38,20 +38,22 @@ Map<K2, V2> mapMap<K1, V1, K2, V2>(Map<K1, V1> map,
 Map<K, V> mergeMaps<K, V>(Map<K, V> map1, Map<K, V> map2,
     {V? Function(V, V)? value, bool removeDifference = false}) {
   var result = Map<K, V>.of(map1);
-  if (value == null) return result..addAll(map2);
-
-  map2.forEach((key, mapValue) {
-    if (result.containsKey(key)) {
-      final newValue = value(result[key] as V, mapValue);
-      if (newValue != null) {
-        result[key] = newValue;
+  if (value == null) {
+    result.addAll(map2);
+  } else {
+    map2.forEach((key, mapValue) {
+      if (result.containsKey(key)) {
+        final newValue = value(result[key] as V, mapValue);
+        if (newValue != null) {
+          result[key] = newValue;
+        } else {
+          result.remove(key);
+        }
       } else {
-        result.remove(key);
+        result[key] = mapValue;
       }
-    } else {
-      result[key] = mapValue;
-    }
-  });
+    });
+  }
 
   if (removeDifference) {
     final removedKeys = <K>[];

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -29,6 +29,12 @@ Map<K2, V2> mapMap<K1, V1, K2, V2>(Map<K1, V1> map,
 /// If there are keys that occur in both maps, the [value] function is used to
 /// select the value that goes into the resulting map based on the two original
 /// values. If [value] is omitted, the value from [map2] is used.
+///
+/// If the any of key's value of [map2] is null then such key will be removed
+/// from result map.
+///
+/// If `removeDifference` is true then keys which do not contains in [map2] will
+/// be removef from result map.
 Map<K, V> mergeMaps<K, V>(Map<K, V> map1, Map<K, V> map2,
     {V? Function(V, V)? value, bool removeDifference = false}) {
   var result = Map<K, V>.of(map1);


### PR DESCRIPTION
The updated version of `mergeMaps` function allows to merge maps with removal functionality.
```dart
final map1 = {'a': 'a'};
final map2 = {'b': 'b'};
final map3 = {'c': 'c'};
final map12 = mergeMaps(map1, map2);                     // {'a': 'a', 'b': 'b'}
final map123 = mergeMaps(map12, map3);                   // {'a': 'a', 'b': 'b', 'c': 'c'}
final map123_reduced1 = mergeMaps(map123, {'c': null});  // {'a': 'a', 'b': 'b'}
final map4 = {'a': 'a', 'b': 'b'};
final map123_reduced2 = mergeMaps(map123, map4, 
 removeDifference: true);                                // {'a': 'a', 'b': 'b'}
```