### PR TITLE
Change `CastError` to `TypeError`, since the former is deprecated.

### DIFF
--- a/lib/src/wrappers.dart
+++ b/lib/src/wrappers.dart
@@ -134,7 +134,7 @@ class DelegatingIterable<E> extends _DelegatingIterableBase<E> {
   ///
   /// This soundly converts an [Iterable] without a generic type to an
   /// `Iterable<E>` by asserting that its elements are instances of `E` whenever
-  /// they're accessed. If they're not, it throws a [CastError].
+  /// they're accessed. If they're not, it throws a [TypeError].
   ///
   /// This forwards all operations to [base], so any changes in [base] will be
   /// reflected in `this`. If [base] is already an `Iterable<E>`, it's returned
@@ -158,8 +158,8 @@ class DelegatingList<E> extends _DelegatingIterableBase<E> implements List<E> {
   ///
   /// This soundly converts a [List] without a generic type to a `List<E>` by
   /// asserting that its elements are instances of `E` whenever they're
-  /// accessed. If they're not, it throws a [CastError]. Note that even if an
-  /// operation throws a [CastError], it may still mutate the underlying
+  /// accessed. If they're not, it throws a [TypeError]. Note that even if an
+  /// operation throws a [TypeError], it may still mutate the underlying
   /// collection.
   ///
   /// This forwards all operations to [base], so any changes in [base] will be
@@ -323,8 +323,8 @@ class DelegatingSet<E> extends _DelegatingIterableBase<E> implements Set<E> {
   ///
   /// This soundly converts a [Set] without a generic type to a `Set<E>` by
   /// asserting that its elements are instances of `E` whenever they're
-  /// accessed. If they're not, it throws a [CastError]. Note that even if an
-  /// operation throws a [CastError], it may still mutate the underlying
+  /// accessed. If they're not, it throws a [TypeError]. Note that even if an
+  /// operation throws a [TypeError], it may still mutate the underlying
   /// collection.
   ///
   /// This forwards all operations to [base], so any changes in [base] will be
@@ -411,8 +411,8 @@ class DelegatingQueue<E> extends _DelegatingIterableBase<E>
   ///
   /// This soundly converts a [Queue] without a generic type to a `Queue<E>` by
   /// asserting that its elements are instances of `E` whenever they're
-  /// accessed. If they're not, it throws a [CastError]. Note that even if an
-  /// operation throws a [CastError], it may still mutate the underlying
+  /// accessed. If they're not, it throws a [TypeError]. Note that even if an
+  /// operation throws a [TypeError], it may still mutate the underlying
   /// collection.
   ///
   /// This forwards all operations to [base], so any changes in [base] will be
@@ -487,8 +487,8 @@ class DelegatingMap<K, V> implements Map<K, V> {
   ///
   /// This soundly converts a [Map] without generic types to a `Map<K, V>` by
   /// asserting that its keys are instances of `E` and its values are instances
-  /// of `V` whenever they're accessed. If they're not, it throws a [CastError].
-  /// Note that even if an operation throws a [CastError], it may still mutate
+  /// of `V` whenever they're accessed. If they're not, it throws a [TypeError].
+  /// Note that even if an operation throws a [TypeError], it may still mutate
   /// the underlying collection.
   ///
   /// This forwards all operations to [base], so any changes in [base] will be

--- a/test/queue_list_test.dart
+++ b/test/queue_list_test.dart
@@ -272,10 +272,7 @@ void main() {
     var numQueue = stringQueue.cast<num>();
     expect(numQueue, const TypeMatcher<QueueList<num>>(),
         reason: 'Expected QueueList<num>, got ${numQueue.runtimeType}');
-    expect(
-        () => numQueue.add(1),
-        // ignore: deprecated_member_use
-        throwsA(isA<CastError>()));
+    expect(() => numQueue.add(1), throwsA(isA<TypeError>()));
   });
 
   test('cast returns a new QueueList', () {


### PR DESCRIPTION
Does not affect any user code, changes are only in tests and documentation.
Failing casts already throw errors which are both `TypeError` and `CastError`, 
and which will be only `TypeErrors` in Dart 3.0 when `CastError` is removed.