### PR TITLE
RFC: Add enumerated extension

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -591,6 +591,45 @@ extension IterableExtension<T> on Iterable<T> {
       yield slice;
     }
   }
+
+  /// Elements paired with their index.
+  ///
+  /// For example, `['A'].enumerated` returns `[Enumerated('A', 0)]`
+  ///
+  /// Common usage:
+  /// ```dart
+  /// for (var el in ['A', 'B', 'C'].enumerated) {
+  ///   print(el.index); // 0, 1, 2
+  ///   print(el.value); // "A", "B", "C"
+  /// }
+  /// ```
+  Iterable<Enumerated<T>> get enumerated sync* {
+    for (var i = 0; i < length; i++) {
+      yield Enumerated<T>(i, elementAt(i));
+    }
+  }
+}
+
+/// An enumerated element from an iterable
+class Enumerated<T> {
+  /// The index of the element from the source iterable
+  final int index;
+
+  /// The value of the element
+  final T value;
+
+  Enumerated(this.index, this.value);
+
+  @override
+  int get hashCode => index.hashCode ^ value.hashCode;
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(other, this) ||
+        (other is Enumerated<T> &&
+            other.index == index &&
+            other.value == value);
+  }
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -833,6 +833,18 @@ void main() {
               ]);
         });
       });
+      group('.enumerated', () {
+        test('empty', () {
+          expect(iterable([]).enumerated, []);
+        });
+        test('single', () {
+          expect(iterable(['A']).enumerated, [Enumerated(0, 'A')]);
+        });
+        test('multiple', () {
+          expect(iterable(['A', 'B', 'C']).enumerated,
+              [Enumerated(0, 'A'), Enumerated(1, 'B'), Enumerated(2, 'C')]);
+        });
+      });
       group('none', () {
         test('empty', () {
           expect(iterable([]).none(unreachable), true);


### PR DESCRIPTION
I have found this extension to be useful, it allows someone to skip the common for loop pattern for accessing elements. It also supersedes the need for specialized methods like `mapIndexed`, `whereIndexed`, (I count 14 in this package). BUT the value seems low because technically we have `asMap` and these specialized methods already

### Before

```dart
for(var i = 0; i < foo.length; i++){
  print(i);
  print(foo[i]);
}
```

```dart
foo.forEach((value){
  final index = foo.indexOf(value);
  print(index);
  print(value);
}
```


### After

```dart
for(final element in foo.enumerated){
  print(element.index);
  print(element.value);
}
```

```dart
foo.enumerated.forEach((element){
  print(element.index);
  print(element.value);
}
```


### Related issues

Lots of JavaScript developers rely on their overloadable map method which allows optionally accessing the index, so tutorials like this are created to shim this missing functionality https://fireship.io/snippets/dart-how-to-get-the-index-on-array-loop-map/

This is a common question on Stack Overflow

<img width="650" alt="Screen Shot 2022-12-21 at 8 49 44 AM" src="https://user-images.githubusercontent.com/666539/208920789-3cfc52b5-c3ac-4855-87f5-9bdb71c00c5c.png">

Entire videos on YouTube are dedicated to helping people with this

https://www.youtube.com/watch?v=HLMzibT2Wms

There are some related issues here, although admittedly they are closed

https://github.com/dart-lang/sdk/issues/49589
https://github.com/dart-lang/sdk/issues/33965
