### PR TITLE
`CanonicalizedMap`: new `copy`, `toMap` and `toMapOfCanonicalKeys` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.17.3
+## 1.18.0-wip
 
 - `CanonicalizedMap`:
   - Added methods:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.17.3
+
+- `CanonicalizedMap`:
+  - Added methods:
+    - `copy`: copies an instance without recalculating the canonical values of the keys.
+    - `toMap`: creates a `Map<K,V>` (with the original key values).
+    - `toMapOfCanonicalKeys`: creates a `Map<C,V>` (with the canonicalized keys).
+- lints: ^2.0.1
+
 ## 1.17.2
 
 * Accept Dart SDK versions above 3.0.

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -46,6 +46,16 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
     addAll(other);
   }
 
+  CanonicalizedMap._(
+      this._canonicalize, this._isValidKeyFn, Map<C, MapEntry<K, V>> base) {
+    _base.addAll(base);
+  }
+
+  /// Copies this [CanonicalizedMap] instance without recalculating the
+  /// canonical values of the keys.
+  CanonicalizedMap<C, K, V> copy() =>
+      CanonicalizedMap._(_canonicalize, _isValidKeyFn, _base);
+
   @override
   V? operator [](Object? key) {
     if (!_isValidKey(key)) return null;
@@ -161,4 +171,13 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
 
   bool _isValidKey(Object? key) =>
       (key is K) && (_isValidKeyFn == null || _isValidKeyFn!(key));
+
+  /// Creates a `Map<K,V>` (with the original key values).
+  /// See [toMapOfCanonicalKeys].
+  Map<K, V> toMap() => Map<K, V>.fromEntries(_base.values);
+
+  /// Creates a `Map<C,V>` (with the canocalized keys).
+  /// See [toMap].
+  Map<C, V> toMapOfCanonicalKeys() => Map<C, V>.fromEntries(
+      _base.entries.map((e) => MapEntry<C, V>(e.key, e.value.value)));
 }

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -176,7 +176,7 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
   /// See [toMapOfCanonicalKeys].
   Map<K, V> toMap() => Map<K, V>.fromEntries(_base.values);
 
-  /// Creates a `Map<C,V>` (with the canocalized keys).
+  /// Creates a `Map<C,V>` (with the canonicalized keys).
   /// See [toMap].
   Map<C, V> toMapOfCanonicalKeys() => Map<C, V>.fromEntries(
       _base.entries.map((e) => MapEntry<C, V>(e.key, e.value.value)));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.17.3
+version: 1.18.0-wip
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.17.2
+version: 1.17.3
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection
 
@@ -11,5 +11,5 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^2.0.1
   test: ^1.16.0

--- a/test/canonicalized_map_test.dart
+++ b/test/canonicalized_map_test.dart
@@ -204,4 +204,61 @@ void main() {
       expect(map['0001'], equals('value 3'));
     });
   });
+
+  group('CanonicalizedMap.toMapOfCanonicalKeys', () {
+    test('convert to a `Map<C,V>`', () {
+      var map = CanonicalizedMap.from(
+          {'1': 'value 1', '2': 'value 2', '3': 'value 3'}, int.parse);
+
+      var map2 = map.toMapOfCanonicalKeys();
+
+      expect(map2, isNot(isA<CanonicalizedMap>()));
+
+      expect(map2[1], equals('value 1'));
+      expect(map2[2], equals('value 2'));
+      expect(map2[3], equals('value 3'));
+
+      expect(map2, equals({1: 'value 1', 2: 'value 2', 3: 'value 3'}));
+    });
+  });
+
+  group('CanonicalizedMap.toMap', () {
+    test('convert to a `Map<K,V>`', () {
+      var map = CanonicalizedMap.from(
+          {'1': 'value 1', '2': 'value 2', '3': 'value 3'}, int.parse);
+
+      var map2 = map.toMap();
+
+      expect(map2, isNot(isA<CanonicalizedMap>()));
+
+      expect(map2['1'], equals('value 1'));
+      expect(map2['2'], equals('value 2'));
+      expect(map2['3'], equals('value 3'));
+
+      expect(map2, equals({'1': 'value 1', '2': 'value 2', '3': 'value 3'}));
+    });
+  });
+
+  group('CanonicalizedMap.copy', () {
+    test('copy instance', () {
+      var map = CanonicalizedMap.from(
+          {'1': 'value 1', '2': 'value 2', '3': 'value 3'}, int.parse);
+
+      var map2 = map.copy();
+
+      expect(map2['01'], equals('value 1'));
+      expect(map2['02'], equals('value 2'));
+      expect(map2['03'], equals('value 3'));
+
+      expect(map2['1'], equals('value 1'));
+      expect(map2['2'], equals('value 2'));
+      expect(map2['3'], equals('value 3'));
+
+      expect(map2, equals({'1': 'value 1', '2': 'value 2', '3': 'value 3'}));
+
+      var map3 = Map.fromEntries(map2.entries);
+
+      expect(map3, equals({'1': 'value 1', '2': 'value 2', '3': 'value 3'}));
+    });
+  });
 }


### PR DESCRIPTION
- `copy`: copies a `CanonicalizedMap` instance without recalculating the canonical values of the keys.
- `toMap`: creates a `Map<K,V>` (with the original key values).
- `toMapOfCanonicalKeys`: creates a `Map<C,V>` (with the canocalized keys).