### PR TITLE
Changes to Equality classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 * Require Dart 2.18
 * Improve docs for `splitAfter` and `splitBefore`.
+* Add `JsonEquality` which is an extra efficient `Equality` on JSON-like
+  object structures. It's less general than `DeepCollectionEquality`,
+  but can therefore make assumptions that allows it to be more efficient.
+* **BREAKING CHANGE**: `MapEquality` no longer uses `keys`-equality
+  to decide whether two maps have the same keys.
+  Instead it assumes that the two maps have compatible key-equalities,
+  and looks up the keys of one map in the other.
+  This change is expected to make the equality more useful,
+  because a `true` result is more likely to mean that one map can be
+  used as a replacement for the other, rather than the maps just happening to
+  have the same keys and values, even when they don't use the same key equality.
+* **BREAKING CHANGE**: `SetEquality` no longer uses only `keys`-equality
+  to decide whether two sets have the same elements.
+  Instead it assumes that the two sets have equalities compatible with the
+  configured element equality, and uses `Set` operations to match an element
+  in one set to an element in the other.
+  This change is expected to make the equality more useful,
+  because a `true` result is more likely to mean that one mapset can be
+  used as a replacement for the other, rather than the set just happening to
+  have the same elements, even when they don't use the same element equality.
+* **BREAKING CHANGE**: The `DeepCollectionEquality.unordered` constructor
+  is now a factory constructor. It creates a subclass which caches equality
+  and hash computations performed by recursive calls
+  to avoid performance issues with deep structures
+  combined with repeated hash/equality checks due to the unordered comparison.
 
 ## 1.17.0
 

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -14,18 +14,25 @@ abstract class Equality<E> {
 
   /// Compare two elements for being equal.
   ///
-  /// This should be a proper equality relation.
+  /// This should be a proper equality relation, meaning that it is:
+  /// * Reflexive. For all applicable values `v`, `eq.equals(v, v)` must
+  ///   be true.
+  /// * Symmetric. For all applicable values `v1` and `v2`,
+  ///   `eq.equals(v1, v2)` must give the same result as `eq.equals(v2, v1)`.
+  /// * Transitive. For all applicable values `v1`, `v2` and `v3`,
+  ///   if `eq.equals(v1, v2)` and `eq.equals(v2, v3)` are both true,
+  ///   then `eq.equals(v1, v3)` must also be true.
   bool equals(E e1, E e2);
 
   /// Get a hashcode of an element.
   ///
   /// The hashcode should be compatible with [equals], so that if
-  /// `equals(a, b)` then `hash(a) == hash(b)`.
+  /// `eq.equals(a, b)` then `eq.hash(a) == eq.hash(b)`.
   int hash(E e);
 
   /// Test whether an object is a valid argument to [equals] and [hash].
   ///
-  /// Some implementations may be restricted to only work on specific types
+  /// Some implementations may be restricted to only work on specific kinds
   /// of objects.
   bool isValidKey(Object? o);
 }
@@ -51,6 +58,11 @@ class EqualityBy<E, F> implements Equality<E> {
 
   final Equality<F> _inner;
 
+  /// Creates equality which compares objects by [comparisonKey].
+  ///
+  /// The values extraced from objects by [comparisonKey]
+  /// are compared and hashed using the [inner] equality,
+  /// which defaults to [Object.==] and [Object.hashCode].
   EqualityBy(F Function(E) comparisonKey,
       [Equality<F> inner = const DefaultEquality<Never>()])
       : _comparisonKey = comparisonKey,
@@ -64,13 +76,7 @@ class EqualityBy<E, F> implements Equality<E> {
   int hash(E e) => _inner.hash(_comparisonKey(e));
 
   @override
-  bool isValidKey(Object? o) {
-    if (o is E) {
-      final value = _comparisonKey(o);
-      return _inner.isValidKey(value);
-    }
-    return false;
-  }
+  bool isValidKey(Object? o) => o is E && _inner.isValidKey(_comparisonKey(o));
 }
 
 /// Equality of objects that compares only the natural equality of the objects.
@@ -78,11 +84,10 @@ class EqualityBy<E, F> implements Equality<E> {
 /// This equality uses the objects' own [Object.==] and [Object.hashCode] for
 /// the equality.
 ///
-/// Note that [equals] and [hash] take `Object`s rather than `E`s. This allows
-/// `E` to be inferred as `Null` in const contexts where `E` wouldn't be a
-/// compile-time constant, while still allowing the class to be used at runtime.
+/// Works on any object, no matter which type argument is provided.
 class DefaultEquality<E> implements Equality<E> {
-  const DefaultEquality();
+  const DefaultEquality._();
+  const factory DefaultEquality() = DefaultEquality<Never>._;
   @override
   bool equals(Object? e1, Object? e2) => e1 == e2;
   @override
@@ -92,12 +97,17 @@ class DefaultEquality<E> implements Equality<E> {
 }
 
 /// Equality of objects that compares only the identity of the objects.
+///
+/// Uses [identical] for [equals] and [identityHashCode] for [hash].
+///
+/// Works on any object, no matter which type argument is provided.
 class IdentityEquality<E> implements Equality<E> {
-  const IdentityEquality();
+  const IdentityEquality._();
+  const factory IdentityEquality() = IdentityEquality<Never>._;
   @override
-  bool equals(E e1, E e2) => identical(e1, e2);
+  bool equals(Object? e1, Object? e2) => identical(e1, e2);
   @override
-  int hash(E e) => identityHashCode(e);
+  int hash(Object? e) => identityHashCode(e);
   @override
   bool isValidKey(Object? o) => true;
 }
@@ -108,7 +118,7 @@ class IdentityEquality<E> implements Equality<E> {
 ///
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
-/// The [hash] of `null` is `null.hashCode`.
+/// The [hash] of `null` is always `null.hashCode`.
 class IterableEquality<E> implements Equality<Iterable<E>> {
   final Equality<E?> _elementEquality;
   const IterableEquality(
@@ -121,12 +131,12 @@ class IterableEquality<E> implements Equality<Iterable<E>> {
     if (elements1 == null || elements2 == null) return false;
     var it1 = elements1.iterator;
     var it2 = elements2.iterator;
-    while (true) {
-      var hasNext = it1.moveNext();
-      if (hasNext != it2.moveNext()) return false;
-      if (!hasNext) return true;
+    bool more1;
+    bool more2;
+    while ((more1 = it1.moveNext()) & (more2 = it2.moveNext())) {
       if (!_elementEquality.equals(it1.current, it2.current)) return false;
     }
+    return more1 == more2;
   }
 
   @override
@@ -262,11 +272,22 @@ class UnorderedIterableEquality<E> extends _UnorderedEquality<E, Iterable<E>> {
 /// Equality of sets.
 ///
 /// Two sets are considered equal if they have the same number of elements,
-/// and the elements of one set can be paired with the elements
-/// of the other set, so that each pair are equal.
+/// and the elements of one set are also elements of the other,
+/// according to the other set, and the actual elements are equal
+/// according to the element equality.
 ///
-/// This equality behaves the same as [UnorderedIterableEquality] except that
-/// it expects sets instead of iterables as arguments.
+/// Sets have an inherent notion of equality (and sometimes hash code)
+/// of elements. Thesets being compared should have compatiable notions
+/// of equality, and the element equality provided in the constructor should
+/// agree with the sets as well.
+/// If not, the equality and hash reported by this class may disagree with
+/// the sets' behavior, and the equality may not be symmetric.
+///
+/// This equality differs from [UnorderedIterableEquality] in that
+/// it uses [Set.contains] to match elements of one set to elements
+/// of the other, instead of matching up elements itself.
+/// This assumes that the equality of the second set is compatible
+/// with the element equality.
 ///
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
@@ -275,40 +296,50 @@ class SetEquality<E> extends _UnorderedEquality<E, Set<E>> {
   const SetEquality([super.elementEquality = const DefaultEquality<Never>()]);
 
   @override
+  bool equals(Set<E>? elements1, Set<E>? elements2) {
+    if (identical(elements1, elements2)) return true;
+    if (elements1 == null || elements2 == null) return false;
+    var length = elements1.length;
+    if (length != elements2.length) return false;
+    for (var element1 in elements1) {
+      var element2 = elements2.lookup(element1);
+      // Type promotion cannot join `E` and `E & Object` into `E`.
+      E nonNullableElement2;
+      if (element2 == null) {
+        if (element2 is! E || !elements2.contains(element1)) return false;
+        nonNullableElement2 = element2; // type `E`
+      } else {
+        nonNullableElement2 = element2; // type `E & Object`
+      }
+      if (!_elementEquality.equals(element1, nonNullableElement2)) return false;
+    }
+    return true;
+  }
+
+  @override
   bool isValidKey(Object? o) => o is Set<E>;
-}
-
-/// Internal class used by [MapEquality].
-///
-/// The class represents a map entry as a single object,
-/// using a combined hashCode and equality of the key and value.
-class _MapEntry {
-  final MapEquality equality;
-  final Object? key;
-  final Object? value;
-  _MapEntry(this.equality, this.key, this.value);
-
-  @override
-  int get hashCode =>
-      (3 * equality._keyEquality.hash(key) +
-          7 * equality._valueEquality.hash(value)) &
-      _hashMask;
-
-  @override
-  bool operator ==(Object other) =>
-      other is _MapEntry &&
-      equality._keyEquality.equals(key, other.key) &&
-      equality._valueEquality.equals(value, other.value);
 }
 
 /// Equality on maps.
 ///
 /// Two maps are equal if they have the same number of entries, and if the
-/// entries of the two maps are pairwise equal on both key and value.
+/// keys of one map are also keys of the other map,
+/// and they have equal values.
+///
+/// Maps have an inherent notion of equality (and sometimes hash code)
+/// of keys. The maps being compared should have compatiable notions
+/// of equality, and the key equality provided in the constructor should
+/// agree with the maps as well.
+/// If not, the equality and hash reported by this class may disagree with
+/// the maps' behavior, and the equality may not be symmetric.
 ///
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
 /// The [hash] of `null` is `null.hashCode`.
+///
+/// The `keys` equality is only used for computing [hash].
+/// The [equals] method only uses keys from one map to
+/// look up in the other map.
 class MapEquality<K, V> implements Equality<Map<K, V>> {
   final Equality<K> _keyEquality;
   final Equality<V> _valueEquality;
@@ -324,17 +355,24 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
     if (map1 == null || map2 == null) return false;
     var length = map1.length;
     if (length != map2.length) return false;
-    Map<_MapEntry, int> equalElementCounts = HashMap();
-    for (var key in map1.keys) {
-      var entry = _MapEntry(this, key, map1[key]);
-      var count = equalElementCounts[entry] ?? 0;
-      equalElementCounts[entry] = count + 1;
-    }
-    for (var key in map2.keys) {
-      var entry = _MapEntry(this, key, map2[key]);
-      var count = equalElementCounts[entry];
-      if (count == null || count == 0) return false;
-      equalElementCounts[entry] = count - 1;
+    for (var entry in map1.entries) {
+      var key = entry.key;
+      var value1 = entry.value;
+      var value2 = map2[key];
+      // Type inference cannot join `V` and `V & Object` below.
+      V nonNullableValue2;
+      if (value2 == null) {
+        // Either `V` accepts `null`, `map2` does not contain `key`, or both.
+        if (value2 is! V || !map2.containsKey(key)) {
+          return false;
+        }
+        nonNullableValue2 = value2;
+      } else {
+        nonNullableValue2 = value2;
+      }
+      if (!_valueEquality.equals(value1, nonNullableValue2)) {
+        return false;
+      }
     }
     return true;
   }
@@ -343,9 +381,10 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
   int hash(Map<K, V>? map) {
     if (map == null) return null.hashCode;
     var hash = 0;
-    for (var key in map.keys) {
-      var keyHash = _keyEquality.hash(key);
-      var valueHash = _valueEquality.hash(map[key] as V);
+    // Unordered hash code.
+    for (var entry in map.entries) {
+      var keyHash = _keyEquality.hash(entry.key);
+      var valueHash = _valueEquality.hash(entry.value);
       hash = (hash + 3 * keyHash + 7 * valueHash) & _hashMask;
     }
     hash = (hash + (hash << 3)) & _hashMask;
@@ -418,23 +457,30 @@ class MultiEquality<E> implements Equality<E> {
 ///
 /// A list is only equal to another list, likewise for sets and maps. All other
 /// iterables are compared as iterables only.
-class DeepCollectionEquality implements Equality {
+class DeepCollectionEquality implements Equality<Object?> {
   final Equality _base;
   final bool _unordered;
-  const DeepCollectionEquality([Equality base = const DefaultEquality<Never>()])
+  const DeepCollectionEquality(
+      [Equality<Object?> base = const DefaultEquality<Never>()])
       : _base = base,
         _unordered = false;
 
   /// Creates a deep equality on collections where the order of lists and
   /// iterables are not considered important. That is, lists and iterables are
   /// treated as unordered iterables.
-  const DeepCollectionEquality.unordered(
-      [Equality base = const DefaultEquality<Never>()])
-      : _base = base,
-        _unordered = true;
+  const factory DeepCollectionEquality.unordered([Equality base]) =
+      _UnorderedDeepCollectionEquality;
+
+  const DeepCollectionEquality._(this._base, this._unordered);
 
   @override
   bool equals(Object? e1, Object? e2) {
+    if (identical(e1, e2)) return true;
+    if (e1 == null || e2 == null) return false;
+    return _equals(e1, e2);
+  }
+
+  bool _equals(Object? e1, Object? e2) {
     if (e1 is Set) {
       return e2 is Set && SetEquality(this).equals(e1, e2);
     }
@@ -457,6 +503,7 @@ class DeepCollectionEquality implements Equality {
 
   @override
   int hash(Object? o) {
+    if (o == null) return o.hashCode;
     if (o is Set) return SetEquality(this).hash(o);
     if (o is Map) return MapEquality(keys: this, values: this).hash(o);
     if (!_unordered) {
@@ -466,6 +513,65 @@ class DeepCollectionEquality implements Equality {
       return UnorderedIterableEquality(this).hash(o);
     }
     return _base.hash(o);
+  }
+
+  @override
+  bool isValidKey(Object? o) =>
+      o is Iterable || o is Map || _base.isValidKey(o);
+}
+
+/// Entry used to cache hash code and equality of an object in an
+/// unordered deep collection equality.
+class _EqualityCache {
+  final Map<Object?, bool> cachedEquals = Map.identity();
+  int? hash;
+  bool? operator [](Object? second) => cachedEquals[second];
+  void operator []=(Object? second, bool value) {
+    cachedEquals[second] = value;
+  }
+}
+
+class _UnorderedDeepCollectionEquality extends DeepCollectionEquality {
+  /// Cache used when doing deep unordered equality.
+  ///
+  /// Avoids recomputing hash and equality of sub-expressions that
+  /// have already been checked.
+  /// Needed because unordered comparison stores values in
+  /// hash tables, and therefore performes repeated hashing and
+  /// equality, and for nested collections, that can have exponential
+  /// time complexity in the depth of the structure.
+  static Map<Object?, _EqualityCache>? _deepEqualityCache;
+
+  const _UnorderedDeepCollectionEquality(
+      [Equality<Object?> base = const DefaultEquality<Never>()])
+      : super._(base, true);
+
+  @override
+  bool equals(Object? e1, Object? e2) {
+    if (identical(e1, e2)) return true;
+    if (e1 == null || e2 == null) return false;
+    var equalityCache = _deepEqualityCache;
+    if (equalityCache != null) {
+      return (equalityCache[e1] ??= _EqualityCache())[e2] ??=
+          super._equals(e1, e2);
+    }
+    return _equalsNewCache(e1, e2);
+  }
+
+  bool _equalsNewCache(e1, e2) {
+    var equalityCache = _deepEqualityCache = Map.identity();
+    try {
+      return (equalityCache[e1] = _EqualityCache())[e2] = super._equals(e1, e2);
+    } finally {
+      _deepEqualityCache = null;
+    }
+  }
+
+  @override
+  int hash(Object? o) {
+    var equalityCache = _deepEqualityCache;
+    if (equalityCache == null) return super.hash(o);
+    return (equalityCache[o] ??= _EqualityCache()).hash ??= super.hash(o);
   }
 
   @override
@@ -488,4 +594,59 @@ class CaseInsensitiveEquality implements Equality<String> {
 
   @override
   bool isValidKey(Object? object) => object is String;
+}
+
+/// Deep equality on JSON-like object structures.
+///
+/// JSON-like objects can be:
+/// * Lists of JSON-like objects.
+/// * Maps with `String` keys and JSON-like objects as values.
+/// * Other objects compared by normal `==`.
+///
+/// Lists are considered equal if they have the same length
+/// and the elements at each index are equal.
+/// Maps are considered equal if they have the same string keys
+/// and their values for each key are equal.
+/// Such maps are assumed to be normal maps using `==` as key equality.
+///
+/// This equality treat any value which is not
+/// a `List<Object?>` or `Map<Object?, Object?>`
+/// as a plain value to be compared using `==`.
+///
+/// Normal JSON structures only contain
+/// strings, numbers, booleans and `null` as such values,
+/// and only strings as map keys.
+/// This equality accepts any other value too, and uses `==` equality
+/// on those as well.
+class JsonEquality implements Equality<Object?> {
+  const JsonEquality();
+
+  @override
+  bool equals(Object? e1, Object? e2) {
+    if (e1 == e2) return true;
+    if (e1 is List) {
+      if (e2 is! List) return false;
+      return const ListEquality(JsonEquality()).equals(e1, e2);
+    }
+    if (e1 is Map<Object?, Object?>) {
+      if (e2 is! Map<Object?, Object?>) return false;
+      // Uses `DefaultEquality` for keys.
+      return const MapEquality<Object?, Object?>(values: JsonEquality())
+          .equals(e1, e2);
+    }
+    return false;
+  }
+
+  @override
+  int hash(Object? e) {
+    if (e is List) return const ListEquality(JsonEquality()).hash(e);
+    if (e is Map<String, Object?>) {
+      return const MapEquality<Object?, Object?>(values: JsonEquality())
+          .hash(e);
+    }
+    return e.hashCode;
+  }
+
+  @override
+  bool isValidKey(Object? o) => true;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Collections and utilities functions and classes related to collecti
 repository: https://github.com/dart-lang/collection
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.19.0-0 <4.0.0"
 
 dev_dependencies:
   lints: ^2.0.0

--- a/test/equality_test.dart
+++ b/test/equality_test.dart
@@ -108,18 +108,21 @@ void main() {
     'x': [o(4), o(5), o(6)],
     'y': [false, true, null]
   };
+  // Equivalent to map1a if values compared as unordered.
   var map2a = {
     'x': [o(3), o(2), o(1)],
     'y': [false, true, null]
   };
+  // Equivalent to map1b if values compared as unordered.
   var map2b = {
     'x': [o(6), o(5), o(4)],
     'y': [null, false, true]
   };
   var l1 = [map1a, map1b];
   var l2 = [map2a, map2b];
-  var s1 = {...l1};
-  var s2 = {map2b, map2a};
+
+  var s1 = {map1a, map1b};
+  var s2 = {map1b, map1a};
 
   var i1 = Iterable.generate(l1.length, (i) => l1[i]);
 
@@ -173,7 +176,7 @@ void main() {
         expect(colleq.equals(map1a, map2a), isFalse);
         expect(colleq.equals(map1b, map2b), isFalse);
         expect(colleq.equals(l1, l2), isFalse);
-        expect(colleq.equals(s1, s2), isFalse);
+        expect(colleq.equals(s1, s2), isTrue);
       });
 
       // TODO: https://github.com/dart-lang/collection/issues/208
@@ -279,4 +282,6 @@ class Element implements Comparable<Element> {
   bool operator ==(Object other) => other is Element && id == other.id;
   @override
   int compareTo(Element other) => id.compareTo(other.id);
+  @override
+  String toString() => "Element($id)";
 }


### PR DESCRIPTION
PROOF-OF-CONCEPT. DO NOT LAND.

`MapEquality` and `SetEquality` now expects the provided equalities to be compatible with the inherent equals (and hash) of the map or set.
That allows using `Map.operator[]` and `Set.lookup` to match entries/elements from one collection with those of the other, instead of building an extra
hash-map on the side to count occurrences.

This helps `DeepCollectionEquality` which is likely to traverse a larger collection structure (mainly maps) and do repeated equals/hash code on sup-components.

For unordered `DeepCollectionEquality`, a cache of computed values is added to avoid repeating the same computation during the traversal of a map-structure.

Smaller changes to other classes: `DefaultEquality` and `IdentityEquality` now have only factory constructors, so cannot be extended. There should be no need for that.

Also adds `JsonEquality` which is tuned to JSON-like map/list/basic-value structures, and which assumes everything uses default `==` equality.


NOTICE: This is probably a breaking change, so the version number should be major-version-incremented.
I believe this package is pinned by Flutter, so that'll be fun. :wink: 