### PR TITLE
Create version which allows Dart 3.0 SDKs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.2
+
+* Allow Dart 3.0.
+
 ## 1.17.1
 
 * Require Dart 2.18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: collection
-version: 1.17.1
+version: 1.17.2
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
This version just allows Dart 3.0 SDKs, a second CL will switch the package to being 3.0 code.
@mit-mit 