### PR TITLE
Update code to Dart 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Require Dart 3.0.
 * Mark mixin classes as `mixin class`.
+* Added a `Map.pairs` extension method to make it easier to work with maps using
+  Dart 3 record types.
 
 ## 1.17.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.18.0
+
+* Require Dart 3.0.
+* Mark mixin classes as `mixin class`.
+
 ## 1.17.2
 
 * Accept Dart SDK versions above 3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 1.17.2
+
+* Accept Dart SDK versions above 3.0.
+
 ## 1.17.1
 
-* Require Dart 2.18
+* Require Dart 2.18.
 * Improve docs for `splitAfter` and `splitBefore`.
 
 ## 1.17.0

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -17,6 +17,7 @@ export 'src/functions.dart';
 export 'src/iterable_extensions.dart';
 export 'src/iterable_zip.dart';
 export 'src/list_extensions.dart';
+export 'src/map_extensions.dart';
 export 'src/priority_queue.dart';
 export 'src/queue_list.dart';
 export 'src/union_set.dart';

--- a/lib/src/boollist.dart
+++ b/lib/src/boollist.dart
@@ -10,7 +10,7 @@ import 'unmodifiable_wrappers.dart' show NonGrowableListMixin;
 /// A space-efficient list of boolean values.
 ///
 /// Uses list of integers as internal storage to reduce memory usage.
-abstract /*mixin*/ class BoolList with ListMixin<bool> {
+abstract final class BoolList with ListMixin<bool> {
   static const int _entryShift = 5;
 
   static const int _bitsPerEntry = 32;
@@ -180,7 +180,7 @@ abstract /*mixin*/ class BoolList with ListMixin<bool> {
   }
 }
 
-class _GrowableBoolList extends BoolList {
+final class _GrowableBoolList extends BoolList {
   static const int _growthFactor = 2;
 
   _GrowableBoolList._withCapacity(int length, int capacity)
@@ -228,7 +228,8 @@ class _GrowableBoolList extends BoolList {
   }
 }
 
-class _NonGrowableBoolList extends BoolList with NonGrowableListMixin<bool> {
+final class _NonGrowableBoolList extends BoolList
+    with NonGrowableListMixin<bool> {
   _NonGrowableBoolList._withCapacity(int length, int capacity)
       : super._(
           Uint32List(BoolList._lengthInWords(capacity)),

--- a/lib/src/boollist.dart
+++ b/lib/src/boollist.dart
@@ -10,7 +10,7 @@ import 'unmodifiable_wrappers.dart' show NonGrowableListMixin;
 /// A space-efficient list of boolean values.
 ///
 /// Uses list of integers as internal storage to reduce memory usage.
-abstract class BoolList with ListMixin<bool> {
+abstract /*mixin*/ class BoolList with ListMixin<bool> {
   static const int _entryShift = 5;
 
   static const int _bitsPerEntry = 32;
@@ -42,18 +42,18 @@ abstract class BoolList with ListMixin<bool> {
   factory BoolList(int length, {bool fill = false, bool growable = false}) {
     RangeError.checkNotNegative(length, 'length');
 
-    BoolList boolist;
+    BoolList boolList;
     if (growable) {
-      boolist = _GrowableBoolList(length);
+      boolList = _GrowableBoolList(length);
     } else {
-      boolist = _NonGrowableBoolList(length);
+      boolList = _NonGrowableBoolList(length);
     }
 
     if (fill) {
-      boolist.fillRange(0, length, true);
+      boolList.fillRange(0, length, true);
     }
 
-    return boolist;
+    return boolList;
   }
 
   /// Creates an empty list of booleans.

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -10,7 +10,7 @@ import 'dart:collection';
 /// more efficient than a [LinkedHashMap] with a custom equality operator
 /// because it only canonicalizes each key once, rather than doing so for each
 /// comparison.
-class CanonicalizedMap<C, K, V> implements Map<K, V> {
+final class CanonicalizedMap<C, K, V> implements Map<K, V> {
   final C Function(K) _canonicalize;
 
   final bool Function(K)? _isValidKeyFn;

--- a/lib/src/combined_wrappers/combined_iterable.dart
+++ b/lib/src/combined_wrappers/combined_iterable.dart
@@ -13,7 +13,7 @@ import 'combined_iterator.dart';
 /// lazily accessing individual iterable instances. This means that if the
 /// underlying iterables change, the [CombinedIterableView] will reflect those
 /// changes.
-class CombinedIterableView<T> extends IterableBase<T> {
+final class CombinedIterableView<T> extends IterableBase<T> {
   /// The iterables that this combines.
   final Iterable<Iterable<T>> _iterables;
 

--- a/lib/src/combined_wrappers/combined_iterator.dart
+++ b/lib/src/combined_wrappers/combined_iterator.dart
@@ -5,7 +5,7 @@
 /// The iterator for `CombinedIterableView` and `CombinedListView`.
 ///
 /// Moves through each iterable's iterator in sequence.
-class CombinedIterator<T> implements Iterator<T> {
+final class CombinedIterator<T> implements Iterator<T> {
   /// The iterators that this combines, or `null` if done iterating.
   ///
   /// Because this comes from a call to [Iterable.map], it's lazy and will

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -9,7 +9,7 @@ import 'comparators.dart';
 const int _hashMask = 0x7fffffff;
 
 /// A generic equality relation on objects.
-abstract class Equality<E> {
+abstract interface class Equality<E> {
   const factory Equality() = DefaultEquality<E>;
 
   /// Compare two elements for being equal.
@@ -46,7 +46,7 @@ abstract class Equality<E> {
 ///
 /// It's also possible to pass an additional equality instance that should be
 /// used to compare the value itself.
-class EqualityBy<E, F> implements Equality<E> {
+final class EqualityBy<E, F> implements Equality<E> {
   final F Function(E) _comparisonKey;
 
   final Equality<F> _inner;
@@ -81,7 +81,7 @@ class EqualityBy<E, F> implements Equality<E> {
 /// Note that [equals] and [hash] take `Object`s rather than `E`s. This allows
 /// `E` to be inferred as `Null` in const contexts where `E` wouldn't be a
 /// compile-time constant, while still allowing the class to be used at runtime.
-class DefaultEquality<E> implements Equality<E> {
+final class DefaultEquality<E> implements Equality<E> {
   const DefaultEquality();
   @override
   bool equals(Object? e1, Object? e2) => e1 == e2;
@@ -92,7 +92,7 @@ class DefaultEquality<E> implements Equality<E> {
 }
 
 /// Equality of objects that compares only the identity of the objects.
-class IdentityEquality<E> implements Equality<E> {
+final class IdentityEquality<E> implements Equality<E> {
   const IdentityEquality();
   @override
   bool equals(E e1, E e2) => identical(e1, e2);
@@ -109,7 +109,7 @@ class IdentityEquality<E> implements Equality<E> {
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
 /// The [hash] of `null` is `null.hashCode`.
-class IterableEquality<E> implements Equality<Iterable<E>> {
+final class IterableEquality<E> implements Equality<Iterable<E>> {
   final Equality<E?> _elementEquality;
   const IterableEquality(
       [Equality<E> elementEquality = const DefaultEquality<Never>()])
@@ -161,7 +161,7 @@ class IterableEquality<E> implements Equality<Iterable<E>> {
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
 /// The [hash] of `null` is `null.hashCode`.
-class ListEquality<E> implements Equality<List<E>> {
+final class ListEquality<E> implements Equality<List<E>> {
   final Equality<E> _elementEquality;
   const ListEquality(
       [Equality<E> elementEquality = const DefaultEquality<Never>()])
@@ -202,7 +202,7 @@ class ListEquality<E> implements Equality<List<E>> {
   bool isValidKey(Object? o) => o is List<E>;
 }
 
-abstract class _UnorderedEquality<E, T extends Iterable<E>>
+abstract final class _UnorderedEquality<E, T extends Iterable<E>>
     implements Equality<T> {
   final Equality<E> _elementEquality;
 
@@ -251,7 +251,8 @@ abstract class _UnorderedEquality<E, T extends Iterable<E>>
 /// Two iterables are considered equal if they have the same number of elements,
 /// and the elements of one set can be paired with the elements
 /// of the other iterable, so that each pair are equal.
-class UnorderedIterableEquality<E> extends _UnorderedEquality<E, Iterable<E>> {
+final class UnorderedIterableEquality<E>
+    extends _UnorderedEquality<E, Iterable<E>> {
   const UnorderedIterableEquality(
       [super.elementEquality = const DefaultEquality<Never>()]);
 
@@ -271,7 +272,7 @@ class UnorderedIterableEquality<E> extends _UnorderedEquality<E, Iterable<E>> {
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
 /// The [hash] of `null` is `null.hashCode`.
-class SetEquality<E> extends _UnorderedEquality<E, Set<E>> {
+final class SetEquality<E> extends _UnorderedEquality<E, Set<E>> {
   const SetEquality([super.elementEquality = const DefaultEquality<Never>()]);
 
   @override
@@ -282,7 +283,7 @@ class SetEquality<E> extends _UnorderedEquality<E, Set<E>> {
 ///
 /// The class represents a map entry as a single object,
 /// using a combined hashCode and equality of the key and value.
-class _MapEntry {
+final class _MapEntry {
   final MapEquality equality;
   final Object? key;
   final Object? value;
@@ -309,7 +310,7 @@ class _MapEntry {
 /// The [equals] and [hash] methods accepts `null` values,
 /// even if the [isValidKey] returns `false` for `null`.
 /// The [hash] of `null` is `null.hashCode`.
-class MapEquality<K, V> implements Equality<Map<K, V>> {
+final class MapEquality<K, V> implements Equality<Map<K, V>> {
   final Equality<K> _keyEquality;
   final Equality<V> _valueEquality;
   const MapEquality(
@@ -372,7 +373,7 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
 /// for `equals(e1, e2)` and `equals(e2, e1)`. This can happen if one equality
 /// considers only `e1` a valid key, and not `e2`, but an equality which is
 /// checked later, allows both.
-class MultiEquality<E> implements Equality<E> {
+final class MultiEquality<E> implements Equality<E> {
   final Iterable<Equality<E>> _equalities;
 
   const MultiEquality(Iterable<Equality<E>> equalities)
@@ -418,7 +419,7 @@ class MultiEquality<E> implements Equality<E> {
 ///
 /// A list is only equal to another list, likewise for sets and maps. All other
 /// iterables are compared as iterables only.
-class DeepCollectionEquality implements Equality {
+final class DeepCollectionEquality implements Equality {
   final Equality _base;
   final bool _unordered;
   const DeepCollectionEquality([Equality base = const DefaultEquality<Never>()])
@@ -476,7 +477,7 @@ class DeepCollectionEquality implements Equality {
 /// String equality that's insensitive to differences in ASCII case.
 ///
 /// Non-ASCII characters are compared as-is, with no conversion.
-class CaseInsensitiveEquality implements Equality<String> {
+final class CaseInsensitiveEquality implements Equality<String> {
   const CaseInsensitiveEquality();
 
   @override

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -5,6 +5,7 @@
 import 'dart:collection';
 import 'dart:math' as math;
 
+import 'map_extensions.dart';
 import 'utils.dart';
 
 /// Creates a new map from [map] with new keys and values.

--- a/lib/src/map_extensions.dart
+++ b/lib/src/map_extensions.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+extension MapExtensions<K, V> on Map<K, V> {
+  /// Like [Map.entries], but returns each entry as a record.
+  Iterable<(K, V)> get pairs => entries.map((e) => (e.key, e.value));
+}

--- a/lib/src/priority_queue.dart
+++ b/lib/src/priority_queue.dart
@@ -21,7 +21,7 @@ import 'utils.dart';
 /// If elements override [Object.==], the `comparison` function must
 /// always give equal objects the same priority,
 /// otherwise [contains] or [remove] might not work correctly.
-abstract class PriorityQueue<E> {
+abstract interface class PriorityQueue<E> {
   /// Creates an empty [PriorityQueue].
   ///
   /// The created [PriorityQueue] is a plain [HeapPriorityQueue].
@@ -168,7 +168,7 @@ abstract class PriorityQueue<E> {
 ///   and is linear, O(n).
 /// * The [toSet] operation effectively adds each element to the new set, taking
 ///   an expected O(n*log(n)) time.
-class HeapPriorityQueue<E> implements PriorityQueue<E> {
+final class HeapPriorityQueue<E> implements PriorityQueue<E> {
   /// Initial capacity of a queue when created, or when added to after a
   /// [clear].
   ///

--- a/lib/src/queue_list.dart
+++ b/lib/src/queue_list.dart
@@ -9,7 +9,9 @@ import 'dart:collection';
 // dart:collection. The only changes are to implement List and to remove methods
 // that are redundant with ListMixin. Remove or simplify it when issue 21330 is
 // fixed.
-class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
+interface class QueueList<E> extends Object
+    with ListMixin<E>
+    implements Queue<E> {
   /// Adapts [source] to be a `QueueList<T>`.
   ///
   /// Any time the class would produce an element that is not a [T], the element
@@ -274,7 +276,7 @@ class QueueList<E> extends Object with ListMixin<E> implements Queue<E> {
   }
 }
 
-class _CastQueueList<S, T> extends QueueList<T> {
+final class _CastQueueList<S, T> extends QueueList<T> {
   final QueueList<S> _delegate;
 
   // Assigns invalid values for head/tail because it uses the delegate to hold

--- a/lib/src/union_set_controller.dart
+++ b/lib/src/union_set_controller.dart
@@ -21,7 +21,7 @@ import 'union_set.dart';
 ///   }
 /// }
 /// ```
-class UnionSetController<E> {
+interface class UnionSetController<E> {
   /// The [UnionSet] that provides a view of the union of sets in `this`.
   final UnionSet<E> set;
 

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -25,7 +25,7 @@ class NonGrowableListView<E> extends DelegatingList<E>
 
 /// Mixin class that implements a throwing version of all list operations that
 /// change the List's length.
-abstract class NonGrowableListMixin<E> implements List<E> {
+abstract mixin class NonGrowableListMixin<E> implements List<E> {
   static Never _throw() {
     throw UnsupportedError('Cannot change the length of a fixed-length list');
   }
@@ -116,7 +116,7 @@ class UnmodifiableSetView<E> extends DelegatingSet<E>
 
 /// Mixin class that implements a throwing version of all set operations that
 /// change the Set.
-abstract /*mixin*/ class UnmodifiableSetMixin<E> implements Set<E> {
+abstract mixin class UnmodifiableSetMixin<E> implements Set<E> {
   static Never _throw() {
     throw UnsupportedError('Cannot modify an unmodifiable Set');
   }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -116,7 +116,7 @@ class UnmodifiableSetView<E> extends DelegatingSet<E>
 
 /// Mixin class that implements a throwing version of all set operations that
 /// change the Set.
-abstract class UnmodifiableSetMixin<E> implements Set<E> {
+abstract /*mixin*/ class UnmodifiableSetMixin<E> implements Set<E> {
   static Never _throw() {
     throw UnsupportedError('Cannot modify an unmodifiable Set');
   }
@@ -164,7 +164,7 @@ abstract class UnmodifiableSetMixin<E> implements Set<E> {
 
 /// Mixin class that implements a throwing version of all map operations that
 /// change the Map.
-abstract class UnmodifiableMapMixin<K, V> implements Map<K, V> {
+abstract /*mixin*/ class UnmodifiableMapMixin<K, V> implements Map<K, V> {
   static Never _throw() {
     throw UnsupportedError('Cannot modify an unmodifiable Map');
   }

--- a/lib/src/unmodifiable_wrappers.dart
+++ b/lib/src/unmodifiable_wrappers.dart
@@ -164,7 +164,7 @@ abstract mixin class UnmodifiableSetMixin<E> implements Set<E> {
 
 /// Mixin class that implements a throwing version of all map operations that
 /// change the Map.
-abstract /*mixin*/ class UnmodifiableMapMixin<K, V> implements Map<K, V> {
+abstract mixin class UnmodifiableMapMixin<K, V> implements Map<K, V> {
   static Never _throw() {
     throw UnsupportedError('Cannot modify an unmodifiable Map');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: collection
-version: 1.17.2
+version: 1.18.0
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Collections and utilities functions and classes related to collecti
 repository: https://github.com/dart-lang/collection
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Collections and utilities functions and classes related to collecti
 repository: https://github.com/dart-lang/collection
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: collection
-version: 1.17.1
+version: 1.17.2
 description: Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dev_dependencies:
   lints: ^2.0.0

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1900,6 +1900,23 @@ void main() {
       });
     });
   });
+
+  group('Map', () {
+    group('pairs', () {
+      test('empty map', () {
+        expect(<int, int>{}.pairs, isEmpty);
+      });
+
+      test('single pair', () {
+        expect(<int, int>{1: 2}.pairs, equals([(1, 2)]));
+      });
+
+      test('multiple pairs', () {
+        expect(<int, int>{1: 2, 3: 4, 5: 6}.pairs,
+            equals([(1, 2), (3, 4), (5, 6)]));
+      });
+    });
+  });
 }
 
 /// Creates a plain iterable not implementing any other class.


### PR DESCRIPTION
Add required `mixin`s. Add some appropriate `final`s.

Should this be a major version increment?

The `final` modifiers are breaking. (But so is the lack of `mixin` modifiers on some classes.)