### PR TITLE
Make sure .sample()'s result is randomized in more cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - `toMap`: creates a `Map<K,V>` (with the original key values).
     - `toMapOfCanonicalKeys`: creates a `Map<C,V>` (with the canonicalized keys).
 - Fixes bugs in `ListSlice.slice` and `ListExtensions.slice`.
+- Better randomization of `IterableExtension.sample` results.
 - lints: ^2.0.1
 
 ## 1.17.2

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -30,23 +30,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// The chosen elements are not in any specific order.
   List<T> sample(int count, [Random? random]) {
     RangeError.checkNotNegative(count, 'count');
-    var iterator = this.iterator;
-    var chosen = <T>[];
-    for (var i = 0; i < count; i++) {
-      if (iterator.moveNext()) {
-        chosen.add(iterator.current);
-      } else {
-        return chosen;
-      }
-    }
-    var index = count;
-    random ??= Random();
-    while (iterator.moveNext()) {
-      index++;
-      var position = random.nextInt(index);
-      if (position < count) chosen[position] = iterator.current;
-    }
-    return chosen;
+    var shuffled = toList()..shuffle(random ??= Random());
+    return shuffled.take(count).toList();
   }
 
   /// The elements that do not satisfy [test].

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -30,8 +30,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// The chosen elements are not in any specific order.
   List<T> sample(int count, [Random? random]) {
     RangeError.checkNotNegative(count, 'count');
-    var shuffled = toList()..shuffle(random ??= Random());
-    return shuffled.take(count).toList();
+    var shuffled = [...this]..shuffle(random ??= Random());
+    return [...shuffled.take(count)];
   }
 
   /// The elements that do not satisfy [test].

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -30,7 +30,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// The chosen elements are not in any specific order.
   List<T> sample(int count, [Random? random]) {
     RangeError.checkNotNegative(count, 'count');
-    var shuffled = [...this]..shuffle(random ??= Random());
+    var shuffled = [...this]..shuffle(random ?? Random());
     return [...shuffled.take(count)];
   }
 

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1159,6 +1159,30 @@ void main() {
           expect(other, some);
         }
       });
+      test('randomized', () {
+        // Check if the result is randomized
+        var input = iterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        // This specific seed causes the first test fail with the older version
+        var random = Random(12355);
+        {
+          // Result of sampling with a number smaller than length is randomized
+          var result = input.sample(9, random);
+          expect(result.length, 9);
+          expect(result.isSorted(cmpInt), false);
+        }
+        {
+          // Result of sampling with a number equal to length is randomized
+          var result = input.sample(10, random);
+          expect(result.length, 10);
+          expect(result.isSorted(cmpInt), false);
+        }
+        {
+          // Result of sampling with a number bigger than length is randomized
+          var result = input.sample(20, random);
+          expect(result.length, 10);
+          expect(result.isSorted(cmpInt), false);
+        }
+      });
     });
     group('.elementAtOrNull', () {
       test('empty', () async {

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1168,19 +1168,21 @@ void main() {
           // Result of sampling with a number smaller than length is randomized
           var result = input.sample(9, random);
           expect(result.length, 9);
-          expect(result.isSorted(cmpInt), false);
+          expect(result.isSorted(cmpInt), isFalse);
         }
         {
           // Result of sampling with a number equal to length is randomized
           var result = input.sample(10, random);
           expect(result.length, 10);
-          expect(result.isSorted(cmpInt), false);
+          expect(result.isSorted(cmpInt), isFalse);
+          expect(UnorderedIterableEquality().equals(input, result), isTrue);
         }
         {
           // Result of sampling with a number bigger than length is randomized
           var result = input.sample(20, random);
           expect(result.length, 10);
-          expect(result.isSorted(cmpInt), false);
+          expect(result.isSorted(cmpInt), isFalse);
+          expect(UnorderedIterableEquality().equals(input, result), isTrue);
         }
       });
     });


### PR DESCRIPTION
Sampling result was always not randomized when requested samples count was equal or smaller than the input list length and was lots of times not randomized when requested samples count was a little smaller than input list length.

This fixes it simply by using core provided .shuffle() and emulates sampling on top of it and provides tests that were failing on the older code but now don't fail.

The older version was only useful when the requested samples count was significantly smaller than total length of the list which isn't always the case and acts surprisingly on the mentioned cases and I'd believe we should we should follow principle of least astonishment as this has made some issues for my flutter app and I've brought an abstract reproduction of the issue below,

Before this change:
```dart
final random = Random(123);
print([1, 2, 3, 4, 5].sample(1, random)); // [3] a random pick
print([1, 2, 3, 4, 5].sample(2, random)); // [5, 4] two random picks
print([1, 2, 3, 4, 5].sample(3, random)); // [1, 2, 5] three random pick, not randomized enough
print([1, 2, 3, 4, 5].sample(4, random)); // [1, 2, 3, 4] at this specific length and random seed no randomization has happened
print([1, 2, 3, 4, 5].sample(5, random)); // [1, 2, 3, 4, 5] no matter the seed no randomization will happen
print([1, 2, 3, 4, 5].sample(6, random)); // [1, 2, 3, 4, 5] //
print([1, 2, 3, 4, 5].sample(10, random)); // [1, 2, 3, 4, 5] //
```

Some of the entries aren't randomized enough. With this change however:
```dart
final random = Random(123);
print([1, 2, 3, 4, 5].sample(1, random)); // [3] randomized pick
print([1, 2, 3, 4, 5].sample(2, random)); // [4, 5] randomized picks
print([1, 2, 3, 4, 5].sample(3, random)); // [5, 1, 4] //
print([1, 2, 3, 4, 5].sample(4, random)); // [1, 2, 4, 3] //
print([1, 2, 3, 4, 5].sample(5, random)); // [5, 3, 2, 1, 4] //
print([1, 2, 3, 4, 5].sample(6, random)); // [5, 2, 1, 3, 4] //
print([1, 2, 3, 4, 5].sample(10, random)); // [4, 3, 2, 5, 1] //
```
