### PR TITLE
Make sure .sample()'s result is randomized in more cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixes bugs in `ListSlice.slice` and `ListExtensions.slice`.
 - Adds `shuffled` to `IterableExtension`.
 - Update to `package:lints` 2.0.1.
+- Better randomization of `IterableExtension.sample` results.
 
 ## 1.17.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
     - `toMapOfCanonicalKeys`: creates a `Map<C,V>` (with the canonicalized keys).
 - Fixes bugs in `ListSlice.slice` and `ListExtensions.slice`.
 - Adds `shuffled` to `IterableExtension`.
+- Shuffle `IterableExtension.sample` results.
 - Update to `package:lints` 2.0.1.
-- Better randomization of `IterableExtension.sample` results.
 
 ## 1.17.2
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -36,7 +36,7 @@ extension IterableExtension<T> on Iterable<T> {
       if (iterator.moveNext()) {
         chosen.add(iterator.current);
       } else {
-        return chosen;
+        return chosen..shuffle();
       }
     }
     var index = count;
@@ -46,7 +46,7 @@ extension IterableExtension<T> on Iterable<T> {
       var position = random.nextInt(index);
       if (position < count) chosen[position] = iterator.current;
     }
-    return chosen;
+    return chosen..shuffle();
   }
 
   /// The elements that do not satisfy [test].

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -32,21 +32,28 @@ extension IterableExtension<T> on Iterable<T> {
     RangeError.checkNotNegative(count, 'count');
     var iterator = this.iterator;
     var chosen = <T>[];
-    for (var i = 0; i < count; i++) {
+    random ??= Random();
+    while (chosen.length < count) {
       if (iterator.moveNext()) {
-        chosen.add(iterator.current);
+        var nextElement = iterator.current;
+        var position = random.nextInt(chosen.length + 1);
+        if (position == chosen.length) {
+          chosen.add(nextElement);
+        } else {
+          chosen.add(chosen[position]);
+          chosen[position] = nextElement;
+        }
       } else {
-        return chosen..shuffle(random);
+        return chosen;
       }
     }
     var index = count;
-    random ??= Random();
     while (iterator.moveNext()) {
       index++;
       var position = random.nextInt(index);
       if (position < count) chosen[position] = iterator.current;
     }
-    return chosen..shuffle(random);
+    return chosen;
   }
 
   /// The elements that do not satisfy [test].

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -36,7 +36,7 @@ extension IterableExtension<T> on Iterable<T> {
       if (iterator.moveNext()) {
         chosen.add(iterator.current);
       } else {
-        return chosen..shuffle();
+        return chosen..shuffle(random);
       }
     }
     var index = count;
@@ -46,7 +46,7 @@ extension IterableExtension<T> on Iterable<T> {
       var position = random.nextInt(index);
       if (position < count) chosen[position] = iterator.current;
     }
-    return chosen..shuffle();
+    return chosen..shuffle(random);
   }
 
   /// The elements that do not satisfy [test].

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1175,31 +1175,30 @@ void main() {
           expect(other, some);
         }
       });
-      test('randomized', () {
-        // Check if the result is randomized
-        var input = iterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        // This specific seed causes the first test fail with the older version
-        var random = Random(12355);
-        {
-          // Result of sampling with a number smaller than length is randomized
+      group('shuffles results', () {
+        late Random random;
+        late Iterable<int> input;
+        setUp(() async {
+          input = iterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+          random = Random(12345);
+        });
+        test('for partial samples of input', () {
           var result = input.sample(9, random);
           expect(result.length, 9);
           expect(result.isSorted(cmpInt), isFalse);
-        }
-        {
-          // Result of sampling with a number equal to length is randomized
+        });
+        test('for complete samples of input', () {
           var result = input.sample(10, random);
           expect(result.length, 10);
           expect(result.isSorted(cmpInt), isFalse);
           expect(UnorderedIterableEquality().equals(input, result), isTrue);
-        }
-        {
-          // Result of sampling with a number bigger than length is randomized
+        });
+        test('for overlengthed samples of input', () {
           var result = input.sample(20, random);
           expect(result.length, 10);
           expect(result.isSorted(cmpInt), isFalse);
           expect(UnorderedIterableEquality().equals(input, result), isTrue);
-        }
+        });
       });
     });
     group('.elementAtOrNull', () {

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1175,6 +1175,32 @@ void main() {
           expect(other, some);
         }
       });
+      test('randomized', () {
+        // Check if the result is randomized
+        var input = iterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        // This specific seed causes the first test fail with the older version
+        var random = Random(12355);
+        {
+          // Result of sampling with a number smaller than length is randomized
+          var result = input.sample(9, random);
+          expect(result.length, 9);
+          expect(result.isSorted(cmpInt), isFalse);
+        }
+        {
+          // Result of sampling with a number equal to length is randomized
+          var result = input.sample(10, random);
+          expect(result.length, 10);
+          expect(result.isSorted(cmpInt), isFalse);
+          expect(UnorderedIterableEquality().equals(input, result), isTrue);
+        }
+        {
+          // Result of sampling with a number bigger than length is randomized
+          var result = input.sample(20, random);
+          expect(result.length, 10);
+          expect(result.isSorted(cmpInt), isFalse);
+          expect(UnorderedIterableEquality().equals(input, result), isTrue);
+        }
+      });
     });
     group('.elementAtOrNull', () {
       test('empty', () async {


### PR DESCRIPTION
Sampling result was always not randomized when requested samples count was equal or smaller than the input list length and was lots of times not randomized when requested samples count was a little smaller than input list length.

This fixes it simply by using core provided .shuffle() and provides tests that was failing on the older code but now don't fail.

As https://github.com/dart-lang/collection/pull/297#issuecomment-1673153583