### PR TITLE
Add noneIndexed, everyIndexed and anyIndexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.19.0-wip
 
 - Adds `shuffled` to `IterableExtension`.
+- Adds `noneIndexed`, `everyIndexed` and `anyIndexed` to `IterableExtension`.
 - Shuffle `IterableExtension.sample` results.
 
 ## 1.18.0

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -582,6 +582,59 @@ extension IterableExtension<T> on Iterable<T> {
     return true;
   }
 
+  /// Whether no element and index satisfies [test].
+  ///
+  /// Returns true if no element and index satisfies [test],
+  /// and false if at least one does.
+  ///
+  /// Equivalent to `iterable.everyIndexed((i, x) => !test(i, x))` or
+  /// `!iterable.anyIndexed(test)`.
+  bool noneIndexed(bool Function(int, T) test) {
+    var index = 0;
+    for (var element in this) {
+      if (test(index++, element)) return false;
+    }
+    return true;
+  }
+
+  /// Checks whether every element and index of this iterable satisfies [test].
+  ///
+  /// Checks every element and index in iteration order, and returns `false` if
+  /// any of them make [test] return `false`, otherwise returns `true`.
+  ///
+  /// Example:
+  /// ```dart
+  /// final elements = [0, 1, 2];
+  /// // Checks whether every element index matches its value.
+  /// final every = elements.everyIndexed((index, value) => index == value); // true
+  /// ```
+  bool everyIndexed(bool Function(int, T) test) {
+    var index = 0;
+    for (var element in this) {
+      if (!test(index++, element)) return false;
+    }
+    return true;
+  }
+
+  /// Checks whether any element and index of this iterable satisfies [test].
+  ///
+  /// Checks every element and index in iteration order, and returns `true` if
+  /// any of them make [test] return `true`, otherwise returns false.
+  ///
+  /// Example:
+  /// ```dart
+  /// final elements = [2, 1, 0];
+  /// // Checks whether any element index matches its value.
+  /// final result = elements.anyIndexed((index, element) => element == index); // true
+  /// ```
+  bool anyIndexed(bool Function(int, T) test) {
+    var index = 0;
+    for (var element in this) {
+      if (test(index++, element)) return true;
+    }
+    return false;
+  }
+
   /// Contiguous slices of `this` with the given [length].
   ///
   /// Each slice is [length] elements long, except for the last one which may be

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -864,6 +864,79 @@ void main() {
           expect(iterable([0, 2, 4, 6, 8, 10]).none(isEven), false);
         });
       });
+      group('noneIndexed', () {
+        test('empty', () {
+          expect(iterable([]).noneIndexed(unreachable), true);
+        });
+        test('single', () {
+          expect(
+              iterable(['0']).noneIndexed(indexMatchesNumericalContent), false);
+          expect(
+              iterable(['1']).noneIndexed(indexMatchesNumericalContent), true);
+        });
+        test('multiple', () {
+          expect(
+            iterable(['4', '3', '0', '1', '0'])
+                .noneIndexed(indexMatchesNumericalContent),
+            true,
+          );
+          expect(
+            iterable(['0', '0', '2', '0', '0'])
+                .noneIndexed(indexMatchesNumericalContent),
+            false,
+          );
+        });
+      });
+      group('everyIndexed', () {
+        test('empty', () {
+          expect(iterable([]).everyIndexed(unreachable), true);
+        });
+        test('single', () {
+          expect(
+            iterable(['0']).everyIndexed(indexMatchesNumericalContent),
+            true,
+          );
+          expect(
+            iterable(['1']).everyIndexed(indexMatchesNumericalContent),
+            false,
+          );
+        });
+        test('multiple', () {
+          expect(
+            iterable(['0', '1', '2', '3', '4'])
+                .everyIndexed(indexMatchesNumericalContent),
+            true,
+          );
+          expect(
+            iterable(['1', '1', '2', '3', '4'])
+                .everyIndexed(indexMatchesNumericalContent),
+            false,
+          );
+        });
+      });
+      group('anyIndexed', () {
+        test('empty', () {
+          expect(iterable([]).anyIndexed(unreachable), false);
+        });
+        test('single', () {
+          expect(
+              iterable(['0']).anyIndexed(indexMatchesNumericalContent), true);
+          expect(
+              iterable(['1']).anyIndexed(indexMatchesNumericalContent), false);
+        });
+        test('multiple', () {
+          expect(
+            iterable(['4', '3', '0', '1', '0'])
+                .anyIndexed(indexMatchesNumericalContent),
+            false,
+          );
+          expect(
+            iterable(['0', '0', '2', '0', '0'])
+                .anyIndexed(indexMatchesNumericalContent),
+            true,
+          );
+        });
+      });
     });
     group('of nullable', () {
       group('.whereNotNull', () {
@@ -1995,3 +2068,7 @@ bool isEven(int x) => x.isEven;
 
 /// Tests an integer for being odd.
 bool isOdd(int x) => x.isOdd;
+
+/// Tests index matches integer numeral content.
+bool indexMatchesNumericalContent(int index, String value) =>
+    index == int.parse(value);


### PR DESCRIPTION
Adds indexed counterpart of none, every and any.
    
I had to remove none, every and any when I needed the element index also so this adds indexed counterpart of them.

JavaScript's every and some also provide index,

 `[1, 2, 3].every((x, i) => (console.log(x, i), true))`

<img width="380" alt="image" src="https://github.com/dart-lang/collection/assets/833473/5a68b436-fa99-49ca-9c94-e70a4f78144c">

`['a', 'b', 'c'].some(console.log)`

<img width="248" alt="image" src="https://github.com/dart-lang/collection/assets/833473/d8d96fe3-ec10-4334-a034-9b2fa18ebef2">


