### PR TITLE
Add subtract to IterableExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.19.0-wip
 
-- Adds `subtract` to `ListExtensions`.
+- Adds `subtract` to `IterableExtension`.
 - Adds `shuffled` to `IterableExtension`.
 - Shuffle `IterableExtension.sample` results.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.19.0-wip
 
+- Adds `subtract` to `ListExtensions`.
 - Adds `shuffled` to `IterableExtension`.
 - Shuffle `IterableExtension.sample` results.
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -605,14 +605,16 @@ extension IterableExtension<T> on Iterable<T> {
   /// Returns an iterable of the elements in this iterable that are not present
   /// in [other].
   ///
-  /// It's aware about occurrence count and removes things only the number of
-  /// times they occurred in [other] but it's indifferent about order items in
-  /// [other].
+  /// It's aware about occurrence count and excludes elements only the number of
+  /// times they occurred in [other] but it's indifferent about order of items
+  /// in [other].
   ///
   /// It assumes the iterable items have consistent `==` and `hashCode`.
   Iterable<T> subtract(Iterable<T> other) sync* {
-    var elementsCount =
-        other.groupFoldBy<T, int>(identity, (count, _) => (count ?? 0) + 1);
+    var elementsCount = <T, int>{};
+    for (var element in other) {
+      elementsCount[element] = (elementsCount[element] ?? 0) + 1;
+    }
     for (var element in this) {
       var count = elementsCount[element];
       if (count == null) {

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -601,6 +601,29 @@ extension IterableExtension<T> on Iterable<T> {
       yield slice;
     }
   }
+
+  /// Returns an iterable of the elements in this iterable that are not present
+  /// in [other].
+  ///
+  /// It's aware about occurrence count and removes things only the number of
+  /// times they occurred in [other] but it's indifferent about order items in
+  /// [other].
+  ///
+  /// It assumes the iterable items have consistent `==` and `hashCode`.
+  Iterable<T> subtract(Iterable<T> other) sync* {
+    var elementsCount =
+        other.groupFoldBy<T, int>(identity, (count, _) => (count ?? 0) + 1);
+    for (var element in this) {
+      var count = elementsCount[element];
+      if (count == null) {
+        yield element;
+      } else if (count == 1) {
+        elementsCount.remove(element);
+      } else {
+        elementsCount[element] = count - 1;
+      }
+    }
+  }
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -297,7 +297,7 @@ extension ListExtensions<E> on List<E> {
   /// It assumes the list items have consistent `==` and `hashCode`.
   Iterable<E> subtract(List<E> other) sync* {
     var elementsCount = other.groupFoldBy<E, int>(
-      (e) => e,
+      identity,
       (previous, element) => (previous ?? 0) + 1,
     );
     for (final element in this) {

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 import 'algorithms.dart';
 import 'algorithms.dart' as algorithms;
 import 'equality.dart';
+import 'iterable_extensions.dart';
 import 'utils.dart';
 
 /// Various extensions on lists of arbitrary elements.
@@ -284,6 +285,29 @@ extension ListExtensions<E> on List<E> {
     if (length < 1) throw RangeError.range(length, 1, null, 'length');
     for (var i = 0; i < this.length; i += length) {
       yield slice(i, min(i + length, this.length));
+    }
+  }
+
+  /// Returns a new list with the elements of [other] are removed from `this`.
+  ///
+  /// It's aware about occurrence count and removes things only the amount
+  /// they are present in [other].
+  Iterable<E> subtract(List<E> other) sync* {
+    var elementsCount = other.groupFoldBy<E, int>(
+      (e) => e,
+      (previous, element) => (previous ?? 0) + 1,
+    );
+    for (final element in this) {
+      var count = elementsCount[element];
+      if (count == null) {
+        yield element;
+      } else {
+        if (count == 1) {
+          elementsCount.remove(element);
+        } else {
+          elementsCount[element] = count - 1;
+        }
+      }
     }
   }
 }

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -288,10 +288,13 @@ extension ListExtensions<E> on List<E> {
     }
   }
 
-  /// Returns a new list with the elements of [other] are removed from `this`.
+  /// Returns an iterable of the elements in this list that are not present in
+  /// [other].
   ///
   /// It's aware about occurrence count and removes things only the amount
   /// they are present in [other].
+  ///
+  /// It assumes the list items have consistent `==` and `hashCode`.
   Iterable<E> subtract(List<E> other) sync* {
     var elementsCount = other.groupFoldBy<E, int>(
       (e) => e,

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -302,12 +302,10 @@ extension ListExtensions<E> on List<E> {
       var count = elementsCount[element];
       if (count == null) {
         yield element;
+      } else if (count == 1) {
+        elementsCount.remove(element);
       } else {
-        if (count == 1) {
-          elementsCount.remove(element);
-        } else {
-          elementsCount[element] = count - 1;
-        }
+        elementsCount[element] = count - 1;
       }
     }
   }

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -296,10 +296,8 @@ extension ListExtensions<E> on List<E> {
   ///
   /// It assumes the list items have consistent `==` and `hashCode`.
   Iterable<E> subtract(List<E> other) sync* {
-    var elementsCount = other.groupFoldBy<E, int>(
-      identity,
-      (previous, element) => (previous ?? 0) + 1,
-    );
+    var elementsCount =
+        other.groupFoldBy<E, int>(identity, (count, _) => (count ?? 0) + 1);
     for (final element in this) {
       var count = elementsCount[element];
       if (count == null) {

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -298,7 +298,7 @@ extension ListExtensions<E> on List<E> {
   Iterable<E> subtract(List<E> other) sync* {
     var elementsCount =
         other.groupFoldBy<E, int>(identity, (count, _) => (count ?? 0) + 1);
-    for (final element in this) {
+    for (var element in this) {
       var count = elementsCount[element];
       if (count == null) {
         yield element;

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -9,7 +9,6 @@ import 'dart:math';
 import 'algorithms.dart';
 import 'algorithms.dart' as algorithms;
 import 'equality.dart';
-import 'iterable_extensions.dart';
 import 'utils.dart';
 
 /// Various extensions on lists of arbitrary elements.
@@ -285,28 +284,6 @@ extension ListExtensions<E> on List<E> {
     if (length < 1) throw RangeError.range(length, 1, null, 'length');
     for (var i = 0; i < this.length; i += length) {
       yield slice(i, min(i + length, this.length));
-    }
-  }
-
-  /// Returns an iterable of the elements in this list that are not present in
-  /// [other].
-  ///
-  /// It's aware about occurrence count and removes things only the amount
-  /// they are present in [other].
-  ///
-  /// It assumes the list items have consistent `==` and `hashCode`.
-  Iterable<E> subtract(List<E> other) sync* {
-    var elementsCount =
-        other.groupFoldBy<E, int>(identity, (count, _) => (count ?? 0) + 1);
-    for (var element in this) {
-      var count = elementsCount[element];
-      if (count == null) {
-        yield element;
-      } else if (count == 1) {
-        elementsCount.remove(element);
-      } else {
-        elementsCount[element] = count - 1;
-      }
     }
   }
 }

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1262,6 +1262,23 @@ void main() {
         expect(l3.toList(), [4, 5]);
       });
     });
+    group('.subtract', () {
+      test('empty', () {
+        expect(iterable(<int>[]).subtract([]), []);
+      });
+      test('returns the same list when it shares nothing with the other', () {
+        expect(iterable([1, 2, 3, 4]).subtract([5]), [1, 2, 3, 4]);
+      });
+      test('removes two element', () {
+        expect(iterable([1, 2, 3, 4]).subtract([2, 3]), [1, 4]);
+      });
+      test('removes only one of the occurrence', () {
+        expect(iterable([1, 2, 2, 3]).subtract([2]), [1, 2, 3]);
+      });
+      test('removes only two of the occurrences', () {
+        expect(iterable([1, 2, 2, 3]).subtract([2, 0, 2]), [1, 3]);
+      });
+    });
   });
 
   group('Comparator', () {
@@ -1951,23 +1968,6 @@ void main() {
         expect(list, [9, 8, 5, 6, 2, 3, 4, 7, 1]);
         list.sortRange(3, 6, cmpIntInverse);
         expect(list, [9, 8, 5, 6, 3, 2, 4, 7, 1]);
-      });
-    });
-    group('.subtract', () {
-      test('empty', () {
-        expect(<int>[].subtract([]), []);
-      });
-      test('returns the same list when it shares nothing with the other', () {
-        expect([1, 2, 3, 4].subtract([5]), [1, 2, 3, 4]);
-      });
-      test('removes two element', () {
-        expect([1, 2, 3, 4].subtract([2, 3]), [1, 4]);
-      });
-      test('removes only one of the occurrence', () {
-        expect([1, 2, 2, 3].subtract([2]), [1, 2, 3]);
-      });
-      test('removes only two of the occurrences', () {
-        expect([1, 2, 2, 3].subtract([2, 0, 2]), [1, 3]);
       });
     });
   });

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1953,6 +1953,23 @@ void main() {
         expect(list, [9, 8, 5, 6, 3, 2, 4, 7, 1]);
       });
     });
+    group('.subtract', () {
+      test('empty', () {
+        expect(<int>[].subtract([]), []);
+      });
+      test('returns the same list when it shares nothing with the other', () {
+        expect([1, 2, 3, 4].subtract([5]), [1, 2, 3, 4]);
+      });
+      test('removes two element', () {
+        expect([1, 2, 3, 4].subtract([2, 3]), [1, 4]);
+      });
+      test('removes only one of the occurrence', () {
+        expect([1, 2, 2, 3].subtract([2]), [1, 2, 3]);
+      });
+      test('removes only two of the occurrences', () {
+        expect([1, 2, 2, 3].subtract([2, 0, 2]), [1, 3]);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Considering views this stackoverflow link has had, https://stackoverflow.com/q/3428536 (637k times atm) I think we can agree list subtract is a popular need for developers. It can have bad implementations like `list(set(x) - set(y))` which results to removal of duplicated items or `O(m * n)` implementations like this https://stackoverflow.com/a/20259489 so as it's easy to write an incorrect implementation I believe we can implement a correct and definite implementation here. I went through mistakes of having incorrect implementations and ruining some app releases with the mistakes and now I like to share my implementation here so others don't go through issues I had.
