### PR TITLE
Add Iterable.countOccurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.19.0-wip
 
-- Adds `shuffled` to `IterableExtension`.
+- Add `Iterable.shuffled` and `Iterable.countOccurrences` extension methods.
 - Shuffle `IterableExtension.sample` results.
 
 ## 1.18.0

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -601,6 +601,29 @@ extension IterableExtension<T> on Iterable<T> {
       yield slice;
     }
   }
+
+  /// Counts the elements of this iterable, and updates a map with the result.
+  ///
+  /// Creates a new map, or starts with [accumulator] if provided.
+  /// For each element of this iterable, the current value of the element in the
+  /// map, with a default of zero if the element doesn't have an entry in the
+  /// map, is increased by one. Returns the updated map.
+  ///
+  /// If no map is provided, the default map is a default Dart hash-based map
+  /// using [Object.==] for equality. That means that distinct-but-equal objects
+  /// are only represented by one of their elements in the resulting map.
+  /// Provide a custom map if a different equality is needed.
+  Map<T, int> countOccurrences([Map<T, int>? accumulator]) {
+    accumulator ??= {};
+    for (var element in this) {
+      accumulator.update(element, _inc, ifAbsent: _one);
+    }
+    return accumulator;
+  }
+
+  static int _inc(int v) => v + 1;
+
+  static int _one() => 1;
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1262,6 +1262,26 @@ void main() {
         expect(l3.toList(), [4, 5]);
       });
     });
+    group('.countOccurrences', () {
+      test('empty', () {
+        expect(iterable(<int>[]).countOccurrences(), const {});
+      });
+      test('empty with an input', () {
+        expect(iterable(<int>[]).countOccurrences({}), const {});
+      });
+      test('count different items', () {
+        expect(
+          iterable([4, 2, 2, 3, 1, 3, 3]).countOccurrences({}),
+          {1: 1, 2: 2, 3: 3, 4: 1},
+        );
+      });
+      test('count different items with an input counter', () {
+        expect(
+          iterable(['a', 'b', 'c', 'b']).countOccurrences({'b': 2, 'f': 5}),
+          {'a': 1, 'b': 4, 'f': 5, 'c': 1},
+        );
+      });
+    });
   });
 
   group('Comparator', () {


### PR DESCRIPTION
As a part https://github.com/dart-lang/collection/pull/306#issuecomment-1682281034

Just am asking again whether you might like creating a [dedicated Counter class just like python](https://docs.python.org/3/library/collections.html#collections.Counter) or a `Map<T, int>` is fine, at least temporarily, I would be happy with either way (and that's why I have considered to create another PR for `removeCounted` after the decision for this)