### PR TITLE
Improve CHANGELOG of the not released yet changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.19.0-wip
 
-- Adds `shuffled` to `IterableExtension`.
-- Shuffle `IterableExtension.sample` results.
+- Add `Iterable.shuffled` extension method.
+- Shuffle `Iterable.sample` results.
 
 ## 1.18.0
 


### PR DESCRIPTION
Now I think this makes it more idiomatic and better match older entries of the CHANGELOG.