### PR TITLE
Add Iterable.intersperse extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.19.0-wip
 
-- Adds `shuffled` to `IterableExtension`.
+- Add `Iterable.shuffled` and `Iterable.intersperse` extension methods.
 - Shuffle `IterableExtension.sample` results.
 
 ## 1.18.0

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -601,6 +601,21 @@ extension IterableExtension<T> on Iterable<T> {
       yield slice;
     }
   }
+
+  /// Insert a specific element between each two elements of this iterator.
+  ///
+  /// For example, `[1, 2, 3].intersperse(0)` returns `(1, 0, 2, 0, 3)`.
+  Iterable<T> intersperse(T element) sync* {
+    var first = true;
+    for (var e in this) {
+      if (first) {
+        first = false;
+      } else {
+        yield element;
+      }
+      yield e;
+    }
+  }
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1262,6 +1262,23 @@ void main() {
         expect(l3.toList(), [4, 5]);
       });
     });
+    group('.intersperse', () {
+      test('empty', () {
+        expect(iterable(<int>[]).intersperse(0), []);
+      });
+      test('one element', () {
+        expect(iterable(<int>[1]).intersperse(0), [1]);
+      });
+      test('two elements', () {
+        expect(iterable(<int>[1, 2]).intersperse(0), [1, 0, 2]);
+      });
+      test('more elements', () {
+        expect(
+          iterable(<int>[1, 2, 3, 4]).intersperse(0),
+          [1, 0, 2, 0, 3, 0, 4],
+        );
+      });
+    });
   });
 
   group('Comparator', () {


### PR DESCRIPTION
I needed something that could add an element between each two elements in a list as I just hardcoded that functionality in my flutter app but now have decided to revise that code so did some research about it as I didn't even know what name that has and eventually reached to https://github.com/apple/swift-algorithms/blob/main/Guides/Intersperse.md which itself is linked to https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-List.html#v:intersperse and https://docs.rs/itertools/0.9.0/itertools/trait.Itertools.html#method.intersperse which felt that makes it enough popular to be added to `collection`. It would be ok also if you would like to rename this to something better.

Or maybe we should have two of them, `intersperse` that mutates a list and `interspersed`, the one who returns a new iterator, or maybe we should provide only one and should be named `interspersed` like swift or we should follow rust and Haskell instead.