### PR TITLE
docs: Add a warning about dart-lang/sdk#43763 to sortedBy

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -72,6 +72,22 @@ extension IterableExtension<T> on Iterable<T> {
   ///
   /// The elements are ordered by the natural ordering of the
   /// property [keyOf] of the element.
+  ///
+  /// Due to https://github.com/dart-lang/sdk/issues/43763
+  /// if you are comparing using int, you will need to use the <num> type
+  /// annotation instead, e.g.
+  ///
+  /// ```dart
+  /// class Foo {
+  ///  final int bar;
+  ///  Foo(this.bar);
+  /// }
+  ///
+  /// final foos = [Foo(1), Foo(2), Foo(3)];
+  /// // final sortedFoos = foos.sortedBy((foo) => foo.bar); // Error
+  /// final sortedFoos = foos.sortedBy((foo) => foo.bar as num); // Works
+  /// final alsoWorks = foos.sortedBy<num>((foo) => foo.bar); // Works
+  /// ```
   List<T> sortedBy<K extends Comparable<K>>(K Function(T element) keyOf) {
     var elements = [...this];
     mergeSortBy<T, K>(elements, keyOf, compareComparable);

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -74,7 +74,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// property [keyOf] of the element.
   ///
   /// Due to https://github.com/dart-lang/sdk/issues/43763
-  /// if you are comparing using int, you will need to use the <num> type
+  /// if you are comparing using int, you will need to use the `num` type
   /// annotation instead, e.g.
   ///
   /// ```dart


### PR DESCRIPTION
dart-lang/sdk#43763 is supposedly hard to fix in the language, but is a common gotcha
when dealing with sortedBy, so the least we can do is at least alert users and tell them
how to work around it.

Fixes https://github.com/dart-lang/core/issues/649.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
