### PR TITLE
Remove IterableExtensions that have exact equivalents in the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.19.0-wip
+## 2.0.0-wip
 
 - Adds `shuffled` to `IterableExtension`.
 - Shuffle `IterableExtension.sample` results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Shuffle `IterableExtension.sample` results.
 - Fix `mergeSort` when the runtime iterable generic is a subtype of the static
   generic.
+- Remove `firstOrNull`, `lastOrNull`, `singleOrNull` and `elementAtOrNull()`
+  from `IterableExtensions`. Since Dart 3.0, exact equivalents to these are
+  available in Dart core, so 'package:collection' would only be shadowing these.
 - Require Dart `^3.1.0`
 - Mark "mixin" classes as `mixin`.
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -269,13 +269,6 @@ extension IterableExtension<T> on Iterable<T> {
     return null;
   }
 
-  /// The first element, or `null` if the iterable is empty.
-  T? get firstOrNull {
-    var iterator = this.iterator;
-    if (iterator.moveNext()) return iterator.current;
-    return null;
-  }
-
   /// The last element satisfying [test], or `null` if there are none.
   T? lastWhereOrNull(bool Function(T element) test) {
     T? result;
@@ -295,12 +288,6 @@ extension IterableExtension<T> on Iterable<T> {
       if (test(index++, element)) result = element;
     }
     return result;
-  }
-
-  /// The last element, or `null` if the iterable is empty.
-  T? get lastOrNull {
-    if (isEmpty) return null;
-    return last;
   }
 
   /// The single element satisfying [test].
@@ -347,32 +334,6 @@ extension IterableExtension<T> on Iterable<T> {
     }
     return result;
   }
-
-  /// The single element of the iterable, or `null`.
-  ///
-  /// The value is `null` if the iterable is empty
-  /// or it contains more than one element.
-  T? get singleOrNull {
-    var iterator = this.iterator;
-    if (iterator.moveNext()) {
-      var result = iterator.current;
-      if (!iterator.moveNext()) {
-        return result;
-      }
-    }
-    return null;
-  }
-
-  /// The [index]th element, or `null` if there is no such element.
-  ///
-  /// Returns the element at position [index] of this iterable,
-  /// just like [elementAt], if this iterable has such an element.
-  /// If this iterable does not have enough elements to have one with the given
-  /// [index], the `null` value is returned, unlike [elementAt] which throws
-  /// instead.
-  ///
-  /// The [index] must not be negative.
-  T? elementAtOrNull(int index) => skip(index).firstOrNull;
 
   /// Associates the elements in `this` by the value returned by [key].
   ///

--- a/lib/src/list_extensions.dart
+++ b/lib/src/list_extensions.dart
@@ -259,17 +259,6 @@ extension ListExtensions<E> on List<E> {
     return true;
   }
 
-  /// The [index]th element, or `null` if there is no such element.
-  ///
-  /// Returns the element at position [index] of this list,
-  /// just like [elementAt], if this list has such an element.
-  /// If this list does not have enough elements to have one with the given
-  /// [index], the `null` value is returned, unlike [elementAt] which throws
-  /// instead.
-  ///
-  /// The [index] must not be negative.
-  E? elementAtOrNull(int index) => (index < length) ? this[index] : null;
-
   /// Contiguous [slice]s of `this` with the given [length].
   ///
   /// Each slice is a view of this list [length] elements long, except for the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.19.0-wip
+version: 2.0.0-wip
 description: >-
   Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -426,17 +426,6 @@ void main() {
               0);
         });
       });
-      group('.firstOrNull', () {
-        test('empty', () {
-          expect(iterable([]).firstOrNull, null);
-        });
-        test('single', () {
-          expect(iterable([1]).firstOrNull, 1);
-        });
-        test('first of multiple', () {
-          expect(iterable([1, 3, 5]).firstOrNull, 1);
-        });
-      });
       group('.lastWhereOrNull', () {
         test('empty', () {
           expect(iterable([]).lastWhereOrNull(unreachable), null);
@@ -472,17 +461,6 @@ void main() {
               iterable([0, 3, 7]).lastWhereIndexedOrNull((i, x) => x.isOdd), 7);
           expect(iterable([0, 3, 7]).lastWhereIndexedOrNull((i, x) => i.isEven),
               7);
-        });
-      });
-      group('.lastOrNull', () {
-        test('empty', () {
-          expect(iterable([]).lastOrNull, null);
-        });
-        test('single', () {
-          expect(iterable([1]).lastOrNull, 1);
-        });
-        test('last of multiple', () {
-          expect(iterable([1, 3, 5]).lastOrNull, 5);
         });
       });
       group('.singleWhereOrNull', () {
@@ -524,17 +502,6 @@ void main() {
           expect(
               iterable([0, 3, 7]).singleWhereIndexedOrNull((i, x) => i.isEven),
               null);
-        });
-      });
-      group('.singleOrNull', () {
-        test('empty', () {
-          expect(iterable([]).singleOrNull, null);
-        });
-        test('single', () {
-          expect(iterable([1]).singleOrNull, 1);
-        });
-        test('multiple', () {
-          expect(iterable([1, 3, 5]).singleOrNull, null);
         });
       });
       group('.lastBy', () {
@@ -1204,21 +1171,6 @@ void main() {
         });
       });
     });
-    group('.elementAtOrNull', () {
-      test('empty', () async {
-        expect(iterable([]).elementAtOrNull(0), isNull);
-      });
-      test('negative index', () async {
-        expect(() => iterable([1]).elementAtOrNull(-1),
-            throwsA(isA<RangeError>()));
-      });
-      test('index within range', () async {
-        expect(iterable([1]).elementAtOrNull(0), 1);
-      });
-      test('index too high', () async {
-        expect(iterable([1]).elementAtOrNull(1), isNull);
-      });
-    });
     group('.slices', () {
       test('empty', () {
         expect(iterable(<int>[]).slices(1), []);
@@ -1818,20 +1770,6 @@ void main() {
         test('varying result', () {
           expect(['a', 'b'].expandIndexed((i, v) => i.isOdd ? ['$i', v] : []),
               ['1', 'b']);
-        });
-      });
-      group('.elementAtOrNull', () {
-        test('empty', () async {
-          expect([].elementAtOrNull(0), isNull);
-        });
-        test('negative index', () async {
-          expect(() => [1].elementAtOrNull(-1), throwsA(isA<RangeError>()));
-        });
-        test('index within range', () async {
-          expect([1].elementAtOrNull(0), 1);
-        });
-        test('index too high', () async {
-          expect([1].elementAtOrNull(1), isNull);
         });
       });
       group('.slices', () {


### PR DESCRIPTION
Since Dart 3.0, these extensions are in the SDK, exported from core: firstOrNull, lastOrNull, singleOrNull, elementAtOrNull

This package already bumped the version to be above that. So, the deletion will not cause any breakage to users, only potential "unused import" warnings.

* Closes dart-lang/core#671

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
