### PR TITLE
Deprecate whereNotNull from IterableNullableExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Shuffle `IterableExtension.sample` results.
 - Fix `mergeSort` when the runtime iterable generic is a subtype of the static
   generic.
+- Deprecate `whereNotNull()` from `IterableNullableExtension`. Use `nonNulls`
+  instead - this is an equivalent extension available in Dart core since
+  version 3.0.
 - Require Dart `^3.1.0`
 - Mark "mixin" classes as `mixin`.
 

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -611,6 +611,7 @@ extension IterableNullableExtension<T extends Object> on Iterable<T?> {
   /// of this iterable, in their original iteration order.
   ///
   /// For an `Iterable<X?>`, this method is equivalent to `.whereType<X>()`.
+  @Deprecated('Use .nonNulls instead.')
   Iterable<T> whereNotNull() sync* {
     for (var element in this) {
       if (element != null) yield element;

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -866,23 +866,6 @@ void main() {
         });
       });
     });
-    group('of nullable', () {
-      group('.whereNotNull', () {
-        test('empty', () {
-          expect(iterable(<int?>[]).whereNotNull(), isEmpty);
-        });
-        test('single', () {
-          expect(iterable(<int?>[null]).whereNotNull(), isEmpty);
-          expect(iterable(<int?>[1]).whereNotNull(), [1]);
-        });
-        test('multiple', () {
-          expect(iterable(<int?>[1, 3, 5]).whereNotNull(), [1, 3, 5]);
-          expect(iterable(<int?>[null, null, null]).whereNotNull(), isEmpty);
-          expect(
-              iterable(<int?>[1, null, 3, null, 5]).whereNotNull(), [1, 3, 5]);
-        });
-      });
-    });
     group('of number', () {
       group('.sum', () {
         test('empty', () {

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -866,6 +866,53 @@ void main() {
         });
       });
     });
+    group('of nullable', () {
+      group('.whereNotNull', () {
+        test('empty', () {
+          expect(
+              iterable(<int?>[])
+                  .whereNotNull(), // ignore: deprecated_member_use_from_same_package
+              isEmpty);
+        });
+        test('single', () {
+          expect(
+              iterable(<int?>[
+                null
+              ]).whereNotNull(), // ignore: deprecated_member_use_from_same_package
+              isEmpty);
+          expect(
+              iterable(<int?>[
+                1
+              ]).whereNotNull(), // ignore: deprecated_member_use_from_same_package
+              [1]);
+        });
+        test('multiple', () {
+          expect(
+              iterable(<int?>[
+                1,
+                3,
+                5
+              ]).whereNotNull(), // ignore: deprecated_member_use_from_same_package
+              [1, 3, 5]);
+          expect(
+              iterable(<int?>[
+                null,
+                null,
+                null
+              ]).whereNotNull(), // ignore: deprecated_member_use_from_same_package
+              isEmpty);
+          expect(
+              iterable(<int?>[
+                1,
+                null,
+                3,
+                null,
+                5
+              ]).whereNotNull(), // ignore: deprecated_member_use_from_same_package
+              [1, 3, 5]);
+        });
+      });
+    });
     group('of number', () {
       group('.sum', () {
         test('empty', () {


### PR DESCRIPTION
Dart SDK since 3.0 has an exact equivalent extension `nonNulls` in the core.

---

* References #330
* Closes #273
* Closes #274

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
