### PR TITLE
Add transitive reduction to the functions library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   generic.
 - Require Dart `^3.1.0`
 - Mark "mixin" classes as `mixin`.
+- Add `transitiveReduction` to the functions library.
 
 ## 1.18.0
 

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -147,6 +147,43 @@ Map<T, Set<T>> transitiveClosure<T>(Map<T, Iterable<T>> graph) {
   return result;
 }
 
+/// Returns the [transitive reduction][] of [graph].
+///
+/// [transitive reduction]: https://en.wikipedia.org/wiki/Transitive_reduction
+///
+/// Interprets [graph] as a directed graph with a vertex for each key and edges
+/// from each key to the values that the key maps to.
+///
+/// Assumes that every vertex in the graph has a key to represent it, even if
+/// that vertex has no outgoing edges. This isn't checked, but if it's not
+/// satisfied, the function may crash or provide unexpected output. For example,
+/// `{"a": ["b"]}` is not valid, but `{"a": ["b"], "b": []}` is.
+Map<T, Set<T>> transitiveReduction<T>(Map<T, Iterable<T>> graph) {
+  // This uses a modified version of the `transitiveClosure` function of this 
+  // library.
+  var result = <T, Set<T>>{};
+  graph.forEach((vertex, edges) {
+    // remove loops before processing.
+    result[vertex] = Set<T>.from(edges.where((edge) => edge != vertex));
+  });
+
+  // Lists are faster to iterate than maps, so we create a list since we're
+  // iterating repeatedly.
+  var keys = graph.keys.toList();
+  for (var vertex1 in keys) {
+    for (var vertex2 in keys) {
+      for (var vertex3 in keys) {
+        if (result[vertex1]!.contains(vertex2) &&
+            result[vertex2]!.contains(vertex3)) {
+          result[vertex1]!.remove(vertex3);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
 /// Returns the [strongly connected components][] of [graph], in topological
 /// order.
 ///

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -295,6 +295,21 @@ void main() {
             'baz': ['foo']
           }));
     });
+    test('handles path with more than 2 edges', () {
+      expect(
+          transitiveReduction({
+            'foo': ['bar', 'baz', 'qux'],
+            'bar': ['baz'],
+            'baz': ['qux'],
+            'qux': [],
+          }),
+          equals({
+            'foo': ['bar'],
+            'bar': ['baz'],
+            'baz': ['qux'],
+            'qux': [],
+          }));
+    });
   });
 
   group('stronglyConnectedComponents()', () {

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
+import 'package:collection/src/functions.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -238,6 +239,60 @@ void main() {
             'foo': ['bar', 'baz', 'foo'],
             'bar': ['baz', 'foo', 'bar'],
             'baz': ['foo', 'bar', 'baz']
+          }));
+    });
+  });
+  
+  group('transitiveReduction()', () {
+    test('returns an empty map for an empty graph', () {
+      expect(transitiveReduction({}), isEmpty);
+    });
+
+    test('returns the input when there are no transitive connections', () {
+      expect(
+          transitiveReduction({
+            'foo': ['bar'],
+            'bar': [],
+            'bang': ['qux', 'zap'],
+            'qux': [],
+            'zap': []
+          }),
+          equals({
+            'foo': ['bar'],
+            'bar': [],
+            'bang': ['qux', 'zap'],
+            'qux': [],
+            'zap': []
+          }));
+    });
+
+    test('reduces transitive connections', () {
+      expect(
+          transitiveReduction({
+            'foo': ['bar', 'baz', 'qux'],
+            'bar': ['baz', 'qux'],
+            'baz': ['qux'],
+            'qux': []
+          }),
+          equals({
+            'foo': ['bar'],
+            'bar': ['baz'],
+            'baz': ['qux'],
+            'qux': [],
+          }));
+    });
+
+    test('handles loops', () {
+      expect(
+          transitiveReduction({
+            'foo': ['bar', 'baz', 'foo'],
+            'bar': ['baz', 'foo', 'bar'],
+            'baz': ['foo', 'bar', 'baz']
+          }),
+          equals({
+            'foo': ['bar'],
+            'bar': ['baz'],
+            'baz': ['foo']
           }));
     });
   });


### PR DESCRIPTION
This PR adds [transitive reduction](https://en.wikipedia.org/wiki/Transitive_reduction) to the functions library. 

I copied and then modified the existing `transitiveClosure` function to reduce the transitive connections instead of flattening them. Similarly for tests, they are the same as the transitive closure ones, but the input and expected results were swapped (where appropriate). 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
