### PR TITLE
Deprecate transitiveClosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   generic.
 - Require Dart `^3.1.0`
 - Mark "mixin" classes as `mixin`.
+- Deprecate `transitiveClosure`. Consider using `package:graphs`.
 
 ## 1.18.0
 

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -120,6 +120,7 @@ S? maxBy<S, T>(Iterable<S> values, T Function(S) orderBy,
 /// that vertex has no outgoing edges. This isn't checked, but if it's not
 /// satisfied, the function may crash or provide unexpected output. For example,
 /// `{"a": ["b"]}` is not valid, but `{"a": ["b"], "b": []}` is.
+@Deprecated('This method will be removed. Consider using package:graphs.')
 Map<T, Set<T>> transitiveClosure<T>(Map<T, Iterable<T>> graph) {
   // This uses [Warshall's algorithm][], modified not to add a vertex from each
   // node to itself.

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:collection/collection.dart';
 import 'package:test/test.dart';
 
@@ -9,7 +12,6 @@ void main() {
   group('mapMap()', () {
     test('with an empty map returns an empty map', () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
           mapMap({},
               key: expectAsync2((_, __) {}, count: 0),
               value: expectAsync2((_, __) {}, count: 0)),
@@ -18,7 +20,6 @@ void main() {
 
     test('with no callbacks, returns a copy of the map', () {
       var map = {'foo': 1, 'bar': 2};
-      // ignore: deprecated_member_use_from_same_package
       var result = mapMap<String, int, String, int>(map);
       expect(result, equals({'foo': 1, 'bar': 2}));
 
@@ -29,7 +30,6 @@ void main() {
 
     test("maps the map's keys", () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
           mapMap<String, int, dynamic, int>({'foo': 1, 'bar': 2},
               key: (dynamic key, dynamic value) => key[value]),
           equals({'o': 1, 'r': 2}));
@@ -37,7 +37,6 @@ void main() {
 
     test("maps the map's values", () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
           mapMap<String, int, String, dynamic>({'foo': 1, 'bar': 2},
               value: (dynamic key, dynamic value) => key[value]),
           equals({'foo': 'o', 'bar': 'r'}));
@@ -45,7 +44,6 @@ void main() {
 
     test("maps both the map's keys and values", () {
       expect(
-          // ignore: deprecated_member_use_from_same_package
           mapMap({'foo': 1, 'bar': 2},
               key: (dynamic key, dynamic value) => '$key$value',
               value: (dynamic key, dynamic value) => key[value]),

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 // ignore_for_file: deprecated_member_use_from_same_package
 
 import 'package:collection/collection.dart';


### PR DESCRIPTION
The algorithm is implemented with a more flexible signature in
`package:graphs`.
See https://github.com/dart-lang/tools/issues/104

Use an `ignore_for_file` rather than comment each usage of the
deprecated APIs.
