### PR TITLE
`CanonicalizedMap`: added constructor `fromEntries`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Shuffle `IterableExtension.sample` results.
 - Fix `mergeSort` when the runtime iterable generic is a subtype of the static
   generic.
+- `CanonicalizedMap`: added constructor `fromEntries`.
 - Require Dart `^3.1.0`
 - Mark "mixin" classes as `mixin`.
 

--- a/lib/src/canonicalized_map.dart
+++ b/lib/src/canonicalized_map.dart
@@ -46,6 +46,23 @@ class CanonicalizedMap<C, K, V> implements Map<K, V> {
     addAll(other);
   }
 
+  /// Creates a canonicalized map that is initialized with the key/value pairs
+  /// of [entries].
+  ///
+  /// The [canonicalize] function should return the canonical value for the
+  /// given key. Keys with the same canonical value are considered equivalent.
+  ///
+  /// The [isValidKey] function is called before calling [canonicalize] for
+  /// methods that take arbitrary objects. It can be used to filter out keys
+  /// that can't be canonicalized.
+  CanonicalizedMap.fromEntries(
+      Iterable<MapEntry<K, V>> entries, C Function(K key) canonicalize,
+      {bool Function(K key)? isValidKey})
+      : _canonicalize = canonicalize,
+        _isValidKeyFn = isValidKey {
+    addEntries(entries);
+  }
+
   CanonicalizedMap._(
       this._canonicalize, this._isValidKeyFn, Map<C, MapEntry<K, V>> base) {
     _base.addAll(base);

--- a/test/canonicalized_map_test.dart
+++ b/test/canonicalized_map_test.dart
@@ -205,7 +205,7 @@ void main() {
     });
   });
 
-  group('CanonicalizedMap.from', () {
+  group('CanonicalizedMap.fromEntries', () {
     test('canonicalizes its keys', () {
       var map = CanonicalizedMap.fromEntries(
           {'1': 'value 1', '2': 'value 2', '3': 'value 3'}.entries, int.parse);

--- a/test/canonicalized_map_test.dart
+++ b/test/canonicalized_map_test.dart
@@ -205,6 +205,24 @@ void main() {
     });
   });
 
+  group('CanonicalizedMap.from', () {
+    test('canonicalizes its keys', () {
+      var map = CanonicalizedMap.fromEntries(
+          {'1': 'value 1', '2': 'value 2', '3': 'value 3'}.entries, int.parse);
+      expect(map['01'], equals('value 1'));
+      expect(map['02'], equals('value 2'));
+      expect(map['03'], equals('value 3'));
+    });
+
+    test('uses the final value for collisions', () {
+      var map = CanonicalizedMap.fromEntries(
+          {'1': 'value 1', '01': 'value 2', '001': 'value 3'}.entries,
+          int.parse);
+      expect(map.length, equals(1));
+      expect(map['0001'], equals('value 3'));
+    });
+  });
+
   group('CanonicalizedMap.toMapOfCanonicalKeys', () {
     test('convert to a `Map<C,V>`', () {
       var map = CanonicalizedMap.from(


### PR DESCRIPTION
Currently, the only way to create a `CanonicalizedMap` is from a fully constructed `Map`.

With `fromEntries`, a common use case, we can avoid the creation of an intermediate `Map`.

### Real-world case:

Avoid unnecessary overhead as seen here:

https://github.com/dart-lang/shelf/blob/master/pkgs/shelf/lib/src/headers.dart#L32

https://github.com/dart-lang/http_parser/blob/master/lib/src/case_insensitive_map.dart#L13

### Reason:

Improve Dart benchmark performance:

https://sharkbench.dev/web

---

- [✅ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
