### PR TITLE
contribute a dart fix declarative fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,23 @@ jobs:
       - name: Run Chrome tests - wasm
         run: dart test --platform chrome --compiler dart2wasm
         if: always() && steps.install.outcome == 'success' && matrix.sdk == 'dev'
+
+  # Test the contributed `dart fix` fixes.
+  dart-fix:
+    needs: analyze
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        sdk: [main]
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: ${{ matrix.sdk }}
+      - name: Install Dart dependencies
+        run: dart pub get
+      - name: Test the declarative fixes
+        run: dart fix --compare-to-golden
+        working-directory: test_fixes

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,8 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 analyzer:
   language:
     strict-casts: true
+  exclude:
+    - test_fixes/**
 
 linter:
   rules:

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+# Please add new fixes to the top of the file. For documentation about this file
+# format, see https://dart.dev/go/data-driven-fixes.
+
+version: 1
+
+transforms:
+  # whereNotNull() => nonNulls
+  # https://github.com/dart-lang/collection/issues/350
+  - title: "Replace with 'nonNulls'"
+    date: 2024-06-11
+    element:
+      uris: [ 'package:collection/collection.dart' ]
+      inClass: 'IterableNullableExtension'
+      method: 'whereNotNull'
+    changes:
+      - kind: 'replacedBy'
+        newElement:
+          uris: [ 'dart:core' ]
+          inClass: 'NullableIterableExtensions'
+          getter: 'nonNulls'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,5 @@ environment:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
+  path: ^1.9.0
   test: ^1.16.0

--- a/test/dart_fix_test.dart
+++ b/test/dart_fix_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+// Used for debugging the test.
+const keepTempDir = false;
+
+void main() {
+  test("'dart fix' integration", () {
+    // create temp dir
+    final tempDir = Directory.systemTemp.createTempSync('test');
+
+    var sdkVersion = Platform.version;
+    if (sdkVersion.contains(' ')) {
+      sdkVersion = sdkVersion.substring(0, sdkVersion.indexOf(' '));
+    }
+
+    try {
+      // set up project
+      writeFile(tempDir, 'pubspec.yaml', '''
+name: test_project
+environment:
+  sdk: '^$sdkVersion'
+dependencies:
+  collection:
+    path: ${Directory.current.path}
+''');
+      final sourceFile = File(p.join('test_fixes', 'renames.dart'));
+      writeFile(
+        tempDir,
+        p.join('lib', sourceFile.name),
+        sourceFile.readAsStringSync(),
+      );
+
+      // run pub get
+      pubGet(tempDir);
+
+      // dart fix
+      dartFix(tempDir);
+
+      // verify no analysis issues
+      dartAnalyze(tempDir);
+    } finally {
+      // ignore: dead_code
+      if (keepTempDir) {
+        print('dart fix test temp dir: ${tempDir.path}');
+      } else {
+        tempDir.deleteSync(recursive: true);
+      }
+    }
+  });
+}
+
+void writeFile(Directory dir, String filePath, String contents) {
+  final file = File(p.join(dir.path, filePath));
+  file.parent.createSync();
+  file.writeAsStringSync(contents);
+}
+
+void pubGet(Directory dir) {
+  exec('pub', ['get'], cwd: dir);
+}
+
+void dartFix(Directory dir) {
+  exec('fix', ['--apply'], cwd: dir);
+}
+
+void dartAnalyze(Directory dir) {
+  exec('analyze', [], cwd: dir);
+}
+
+void exec(String command, List<String> args, {required Directory cwd}) {
+  printOnFailure('dart $command ${args.join(', ')}');
+
+  final result = Process.runSync(
+    Platform.resolvedExecutable,
+    [command, ...args],
+    workingDirectory: cwd.path,
+  );
+
+  var out = result.stdout as String;
+  if (out.isNotEmpty) printOnFailure(out);
+  out = result.stderr as String;
+  if (out.isNotEmpty) printOnFailure(out);
+
+  if (result.exitCode != 0) {
+    fail('dart $command: exitCode ${result.exitCode}');
+  }
+}
+
+extension on File {
+  String get name => p.basename(path);
+}

--- a/test_fixes/README.md
+++ b/test_fixes/README.md
@@ -1,0 +1,20 @@
+## What's here?
+
+For information about the files in this directory, see
+https://github.com/flutter/flutter/wiki/Data-driven-Fixes#testing.
+
+## Organization
+
+The contents of this directory are used to test the `dart fix` refactorings
+offered by this package. See `lib/dart_fix.yaml` for the fix definitions.
+
+Note that files in this directory are excluded from analysis.
+
+## Running the dart fix tests
+
+In order to test the fixes manually:
+
+```bash
+> cd test_fixes
+> dart fix --compare-to-golden
+```

--- a/test_fixes/analysis_options.yaml
+++ b/test_fixes/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/test_fixes/renames.dart
+++ b/test_fixes/renames.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+
+void main() {
+  final list1 = <String?>['foo', 'bar', null, 'baz'];
+  // ignore: unused_local_variable
+  final list2 = list1.whereNotNull();
+}

--- a/test_fixes/renames.dart.expect
+++ b/test_fixes/renames.dart.expect
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+
+void main() {
+  final list1 = <String?>['foo', 'bar', null, 'baz'];
+  // ignore: unused_local_variable
+  final list2 = list1.nonNulls;
+}


### PR DESCRIPTION
Contribute a dart fix declarative fix:

- address https://github.com/dart-lang/collection/issues/350
- this covers the `whereNotNull()` => `nonNulls` change (deprecating `whereNotNull()`)
- contribute related test infra

Note that this change is currently not working; `dart fix` may not have seen this exact use case before (replacing a deprecated extension method with an extension getter).

cc @keertip for FYI

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
