### PR TITLE
Fix issue 355 added get frequency getter to iterable 

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -602,11 +602,16 @@ extension IterableExtension<T> on Iterable<T> {
     }
   }
 
-  /// Returns a map where the keys are the unique elements of the iterable
-  /// and the values are the counts of those elements.
+  /// The count of occurrences of each element.
   ///
-  /// for example, ['a', 'b', 'b', 'c', 'c', 'c'].frequencies;
-  /// returns {'a': 1, 'b': 2, 'c': 3}.
+  /// The map has an entry for each distinct element of this iterable,
+  /// as determined by `==`, where the value is the number of eelements
+  /// in this iterable which are equal to the key. 
+  /// If there are elements that are equal, but not identical, its unspecified
+  /// which of the elements is used as the key.
+  ///
+  /// For example `['a', 'b', 'c', 'b', 'c', 'c'].frequencies` 
+  /// is a map with entries like `{'a': 1, 'b': 2, 'c': 3}`.
   Map<T, int> get frequencies {
     final frequencyMap = <T, int>{};
     for (var item in this) {

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -597,12 +597,15 @@ extension IterableExtension<T> on Iterable<T> {
   /// for example, ['a', 'b', 'b', 'c', 'c', 'c'].frequencies;
   /// returns {'a': 1, 'b': 2, 'c': 3}.
   Map<T, int> get frequencies {
-    var frequencyMap = <T, int>{};
+    final frequencyMap = <T, int>{};
     for (var item in this) {
-      frequencyMap[item] = (frequencyMap[item] ?? 0) + 1;
+      frequencyMap.update(item, _increment, ifAbsent: _one);
     }
     return frequencyMap;
   }
+
+  static int _increment(int value) => value + 1;
+  static int _one() => 1;
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -601,6 +601,19 @@ extension IterableExtension<T> on Iterable<T> {
       yield slice;
     }
   }
+
+  /// Returns a map where the keys are the unique elements of the iterable
+  /// and the values are the counts of those elements.
+  ///
+  /// for example, ['a', 'b', 'b', 'c', 'c', 'c'].countFrequency()
+  /// returns {'a': 1, 'b': 2, 'c': 3}. will it works?
+  Map<T, int> countFrequency() {
+    var frequencyMap = <T, int>{};
+    for (var item in this) {
+      frequencyMap[item] = (frequencyMap[item] ?? 0) + 1;
+    }
+    return frequencyMap;
+  }
 }
 
 /// Extensions that apply to iterables with a nullable element type.

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -604,14 +604,28 @@ extension IterableExtension<T> on Iterable<T> {
 
   /// The count of occurrences of each element.
   ///
-  /// The map has an entry for each distinct element of this iterable,
-  /// as determined by `==`, where the value is the number of eelements
-  /// in this iterable which are equal to the key. 
-  /// If there are elements that are equal, but not identical, its unspecified
-  /// which of the elements is used as the key.
+  /// The map contains an entry for each unique element of this iterable,
+  /// as determined by `==`.
+  /// The value for each key is the number of times that element 
+  /// appears in the iterable.
   ///
-  /// For example `['a', 'b', 'c', 'b', 'c', 'c'].frequencies` 
-  /// is a map with entries like `{'a': 1, 'b': 2, 'c': 3}`.
+  /// If there are elements that are equal (`==`), 
+  /// but not identical (`identical`), 
+  /// it is unspecified which of the elements is used as the key in the map. 
+  /// For example, if there are multiple lists with the same content, 
+  /// the map will only keep one of them as a key.
+  ///
+  /// Example:
+  /// ```dart
+  /// ['a', 'b', 'c', 'b', 'c', 'c'].frequencies; 
+  /// Returns: {'a': 1, 'b': 2, 'c': 3}.
+  /// ```
+  ///
+  /// Note: This method uses `==` to compare elements. 
+  /// For collections # `List`, `Set`, or `Map`, deep equality is not checked. 
+  /// If you need deep equality (e.g., nested lists),
+  /// consider using a custom equality mechanism.
+
   Map<T, int> get frequencies {
     final frequencyMap = <T, int>{};
     for (var item in this) {

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -605,8 +605,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// Returns a map where the keys are the unique elements of the iterable
   /// and the values are the counts of those elements.
   ///
-  /// for example, ['a', 'b', 'b', 'c', 'c', 'c'].countFrequency()
-  /// returns {'a': 1, 'b': 2, 'c': 3}.
+  /// For example, `['a', 'b', 'b', 'c', 'c', 'c'].countFrequency()`
+  /// returns `{'a': 1, 'b': 2, 'c': 3}`.
   Map<T, int> countFrequency() {
     var frequencyMap = <T, int>{};
     for (var item in this) {

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -57,7 +57,8 @@ extension IterableExtension<T> on Iterable<T> {
   }
 
   /// The elements that do not satisfy [test].
-  Iterable<T> whereNot(bool Function(T element) test) => where((element) => !test(element));
+  Iterable<T> whereNot(bool Function(T element) test) =>
+      where((element) => !test(element));
 
   /// Creates a sorted list of the elements of the iterable.
   ///
@@ -81,7 +82,8 @@ extension IterableExtension<T> on Iterable<T> {
   ///
   /// The elements are ordered by the [compare] [Comparator] of the
   /// property [keyOf] of the element.
-  List<T> sortedByCompare<K>(K Function(T element) keyOf, Comparator<K> compare) {
+  List<T> sortedByCompare<K>(
+      K Function(T element) keyOf, Comparator<K> compare) {
     var elements = [...this];
     mergeSortBy<T, K>(elements, keyOf, compare);
     return elements;
@@ -128,7 +130,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// Applies [keyOf] to each element in iteration order,
   /// then checks whether the results are in non-decreasing order
   /// using the [compare] [Comparator]..
-  bool isSortedByCompare<K>(K Function(T element) keyOf, Comparator<K> compare) {
+  bool isSortedByCompare<K>(
+      K Function(T element) keyOf, Comparator<K> compare) {
     var iterator = this.iterator;
     if (!iterator.moveNext()) return true;
     var previousKey = keyOf(iterator.current);
@@ -198,7 +201,8 @@ extension IterableExtension<T> on Iterable<T> {
   }
 
   /// Expands each element and index to a number of elements in a new iterable.
-  Iterable<R> expandIndexed<R>(Iterable<R> Function(int index, T element) expand) sync* {
+  Iterable<R> expandIndexed<R>(
+      Iterable<R> Function(int index, T element) expand) sync* {
     var index = 0;
     for (var element in this) {
       yield* expand(index++, element);
@@ -236,7 +240,8 @@ extension IterableExtension<T> on Iterable<T> {
   ///
   /// Returns the result of the last call to [combine],
   /// or [initialValue] if there are no elements.
-  R foldIndexed<R>(R initialValue, R Function(int index, R previous, T element) combine) {
+  R foldIndexed<R>(
+      R initialValue, R Function(int index, R previous, T element) combine) {
     var result = initialValue;
     var index = 0;
     for (var element in this) {
@@ -389,7 +394,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// iterable.groupFoldBy(keyOf,
   ///     (Set<T>? previous, T element) => (previous ?? <T>{})..add(element));
   /// ````
-  Map<K, G> groupFoldBy<K, G>(K Function(T element) keyOf, G Function(G? previous, T element) combine) {
+  Map<K, G> groupFoldBy<K, G>(
+      K Function(T element) keyOf, G Function(G? previous, T element) combine) {
     var result = <K, G>{};
     for (var element in this) {
       var key = keyOf(element);
@@ -430,7 +436,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// var parts = [1, 0, 2, 1, 5, 7, 6, 8, 9].splitBefore(isPrime);
   /// print(parts); // ([1, 0], [2, 1], [5], [7, 6, 8, 9])
   /// ```
-  Iterable<List<T>> splitBefore(bool Function(T element) test) => splitBeforeIndexed((_, element) => test(element));
+  Iterable<List<T>> splitBefore(bool Function(T element) test) =>
+      splitBeforeIndexed((_, element) => test(element));
 
   /// Splits the elements into chunks after some elements.
   ///
@@ -446,7 +453,8 @@ extension IterableExtension<T> on Iterable<T> {
   /// var parts = [1, 0, 2, 1, 5, 7, 6, 8, 9].splitAfter(isPrime);
   /// print(parts); // ([1, 0, 2], [1, 5], [7], [6, 8, 9])
   /// ```
-  Iterable<List<T>> splitAfter(bool Function(T element) test) => splitAfterIndexed((_, element) => test(element));
+  Iterable<List<T>> splitAfter(bool Function(T element) test) =>
+      splitAfterIndexed((_, element) => test(element));
 
   /// Splits the elements into chunks between some elements.
   ///
@@ -478,7 +486,8 @@ extension IterableExtension<T> on Iterable<T> {
   ///     .splitBeforeIndexed((i, v) => i < v);
   /// print(parts); // ([1], [0, 2], [1, 5, 7], [6, 8, 9])
   /// ```
-  Iterable<List<T>> splitBeforeIndexed(bool Function(int index, T element) test) sync* {
+  Iterable<List<T>> splitBeforeIndexed(
+      bool Function(int index, T element) test) sync* {
     var iterator = this.iterator;
     if (!iterator.moveNext()) {
       return;
@@ -512,7 +521,8 @@ extension IterableExtension<T> on Iterable<T> {
   ///   .splitAfterIndexed((i, v) => i < v);
   /// print(parts); // ([1, 0], [2, 1], [5, 7, 6], [8, 9])
   /// ```
-  Iterable<List<T>> splitAfterIndexed(bool Function(int index, T element) test) sync* {
+  Iterable<List<T>> splitAfterIndexed(
+      bool Function(int index, T element) test) sync* {
     var index = 0;
     List<T>? chunk;
     for (var element in this) {
@@ -539,7 +549,8 @@ extension IterableExtension<T> on Iterable<T> {
   ///    .splitBetweenIndexed((i, v1, v2) => v1 > v2);
   /// print(parts); // ([1], [0, 2], [1, 5, 7], [6, 8, 9])
   /// ```
-  Iterable<List<T>> splitBetweenIndexed(bool Function(int index, T first, T second) test) sync* {
+  Iterable<List<T>> splitBetweenIndexed(
+      bool Function(int index, T first, T second) test) sync* {
     var iterator = this.iterator;
     if (!iterator.moveNext()) return;
     var previous = iterator.current;
@@ -1002,7 +1013,8 @@ extension ComparatorExtension<T> on Comparator<T> {
   ///
   /// Compares [R] values by comparing their [keyOf] value
   /// using this comparator.
-  Comparator<R> compareBy<R>(T Function(R) keyOf) => (R a, R b) => this(keyOf(a), keyOf(b));
+  Comparator<R> compareBy<R>(T Function(R) keyOf) =>
+      (R a, R b) => this(keyOf(a), keyOf(b));
 
   /// Combine comparators sequentially.
   ///

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -607,7 +607,7 @@ extension IterableExtension<T> on Iterable<T> {
   ///
   /// for example, ['a', 'b', 'b', 'c', 'c', 'c'].countFrequency()
   /// returns {'a': 1, 'b': 2, 'c': 3}.
-  Map<T, int> countFrequency() {
+  Map<T, int> get frequencies {
     var frequencyMap = <T, int>{};
     for (var item in this) {
       frequencyMap[item] = (frequencyMap[item] ?? 0) + 1;

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -606,7 +606,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// and the values are the counts of those elements.
   ///
   /// for example, ['a', 'b', 'b', 'c', 'c', 'c'].countFrequency()
-  /// returns {'a': 1, 'b': 2, 'c': 3}. will it works?
+  /// returns {'a': 1, 'b': 2, 'c': 3}.
   Map<T, int> countFrequency() {
     var frequencyMap = <T, int>{};
     for (var item in this) {

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
 import 'dart:math' show Random, pow;
 
 import 'package:collection/collection.dart';
@@ -1350,6 +1351,84 @@ void main() {
         var l3 = l2.slice(2, 4); // (4..5)
         expect(l3, [4, 5]);
         expect(l3.toList(), [4, 5]);
+      });
+    });
+    group('FrequencyCounter tests', () {
+      test('should return correct frequency map for List of integers', () {
+        var list = [1, 2, 2, 3, 3, 3];
+        var frequencyMap = list.countFrequency();
+        expect(frequencyMap, {1: 1, 2: 2, 3: 3});
+      });
+
+      test('should return correct frequency map for List of strings', () {
+        var list = ['a', 'b', 'b', 'c', 'c', 'c'];
+        var frequencyMap = list.countFrequency();
+        expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('should handle empty List', () {
+        var list = [];
+        var frequencyMap = list.countFrequency();
+        expect(frequencyMap, {});
+      });
+
+      test('should handle single element List', () {
+        var list = [42];
+        var frequencyMap = list.countFrequency();
+        expect(frequencyMap, {42: 1});
+      });
+
+      test('should return correct frequency map for Set of integers', () {
+        // ignore: equal_elements_in_set
+        var set = {1, 2, 2, 3, 3, 3};
+        var frequencyMap = set.countFrequency();
+        expect(frequencyMap, {1: 1, 2: 1, 3: 1});
+      });
+
+      test('should return correct frequency map for Set of strings', () {
+        // ignore: equal_elements_in_set
+        var set = {'a', 'b', 'b', 'c', 'c', 'c'};
+        var frequencyMap = set.countFrequency();
+        expect(frequencyMap, {'a': 1, 'b': 1, 'c': 1});
+      });
+
+      test('should handle empty Set', () {
+        var set = <int>{};
+        var frequencyMap = set.countFrequency();
+        expect(frequencyMap, {});
+      });
+
+      test('should handle single element Set', () {
+        var set = {42};
+        var frequencyMap = set.countFrequency();
+        expect(frequencyMap, {42: 1});
+      });
+
+      test('should return correct frequency map for Queue of integers', () {
+        var queue = Queue<int>();
+        queue.addAll([1, 2, 2, 3, 3, 3]);
+        var frequencyMap = queue.countFrequency();
+        expect(frequencyMap, {1: 1, 2: 2, 3: 3});
+      });
+
+      test('should return correct frequency map for Queue of strings', () {
+        var queue = Queue<String>();
+        queue.addAll(['a', 'b', 'b', 'c', 'c', 'c']);
+        var frequencyMap = queue.countFrequency();
+        expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('should handle empty Queue', () {
+        var queue = Queue<int>();
+        var frequencyMap = queue.countFrequency();
+        expect(frequencyMap, {});
+      });
+
+      test('should handle single element Queue', () {
+        var queue = Queue<int>();
+        queue.add(42);
+        var frequencyMap = queue.countFrequency();
+        expect(frequencyMap, {42: 1});
       });
     });
   });

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1353,7 +1353,7 @@ void main() {
         expect(l3.toList(), [4, 5]);
       });
     });
-    group('FrequencyCounter tests', () {
+    group('get frequencies tests', () {
       test('should return correct frequency map for List of integers', () {
         var list = [1, 2, 2, 3, 3, 3];
         var frequencyMap = list.frequencies;

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1356,78 +1356,78 @@ void main() {
     group('FrequencyCounter tests', () {
       test('should return correct frequency map for List of integers', () {
         var list = [1, 2, 2, 3, 3, 3];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {1: 1, 2: 2, 3: 3});
       });
 
       test('should return correct frequency map for List of strings', () {
         var list = ['a', 'b', 'b', 'c', 'c', 'c'];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
       });
 
       test('should handle empty List', () {
         var list = [];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {});
       });
 
       test('should handle single element List', () {
         var list = [42];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {42: 1});
       });
 
       test('should return correct frequency map for Set of integers', () {
         // ignore: equal_elements_in_set
         var set = {1, 2, 2, 3, 3, 3};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {1: 1, 2: 1, 3: 1});
       });
 
       test('should return correct frequency map for Set of strings', () {
         // ignore: equal_elements_in_set
         var set = {'a', 'b', 'b', 'c', 'c', 'c'};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {'a': 1, 'b': 1, 'c': 1});
       });
 
       test('should handle empty Set', () {
         var set = <int>{};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {});
       });
 
       test('should handle single element Set', () {
         var set = {42};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {42: 1});
       });
 
       test('should return correct frequency map for Queue of integers', () {
         var queue = Queue<int>();
         queue.addAll([1, 2, 2, 3, 3, 3]);
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {1: 1, 2: 2, 3: 3});
       });
 
       test('should return correct frequency map for Queue of strings', () {
         var queue = Queue<String>();
         queue.addAll(['a', 'b', 'b', 'c', 'c', 'c']);
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
       });
 
       test('should handle empty Queue', () {
         var queue = Queue<int>();
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {});
       });
 
       test('should handle single element Queue', () {
         var queue = Queue<int>();
         queue.add(42);
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {42: 1});
       });
     });

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1431,6 +1431,44 @@ void main() {
         expect(frequencyMap, {42: 1});
       });
     });
+
+    group('get frequencies tests extended', () {
+      test('list of equal but not identical strings', () {
+        var list = ['apple', String.fromCharCodes('apple'.codeUnits)];
+        var frequencyMap = list.frequencies;
+        expect(frequencyMap, {'apple': 2});
+      });
+
+      test('list of records', () {
+        var list = [(1, 'a'), (1, 'a'), (2, 'b'), (1, 'a')];
+        var frequencyMap = list.frequencies;
+        expect(frequencyMap, {(1, 'a'): 3, (2, 'b'): 1});
+      });
+
+      test('list with elements that are objects', () {
+        var list = [const MyObject(1), const MyObject(1), const MyObject(2)];
+        var frequencyMap = list.frequencies;
+        expect(frequencyMap, {const MyObject(1): 2, const MyObject(2): 1});
+      });
+
+      test('list with equal numbers but different types', () {
+        var list = [1, 1.0, 1, 1.0];
+        var frequencyMap = list.frequencies;
+        expect(frequencyMap, {1: 4,});
+      });
+
+      test('list with mixed data types', () {
+        var list = [1, 'one', true, 1, 'one', false];
+        var frequencyMap = list.frequencies;
+        expect(frequencyMap, {1: 2, 'one': 2, true: 1, false: 1});
+      });
+
+      test('list with null values', () {
+        var list = [null, null, 1, 'null'];
+        var frequencyMap = list.frequencies;
+        expect(frequencyMap, {null: 2, 1: 1, 'null': 1});
+      });
+    });
   });
 
   group('Comparator', () {
@@ -2123,6 +2161,18 @@ void main() {
       });
     });
   });
+}
+
+class MyObject {
+  final int id;
+  const MyObject(this.id);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is MyObject && id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
 }
 
 /// Creates a plain iterable not implementing any other class.

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1353,81 +1353,81 @@ void main() {
         expect(l3.toList(), [4, 5]);
       });
     });
-    group('get frequencies tests', () {
+    group('FrequencyCounter tests', () {
       test('should return correct frequency map for List of integers', () {
         var list = [1, 2, 2, 3, 3, 3];
-        var frequencyMap = list.frequencies;
+        var frequencyMap = list.countFrequency();
         expect(frequencyMap, {1: 1, 2: 2, 3: 3});
       });
 
       test('should return correct frequency map for List of strings', () {
         var list = ['a', 'b', 'b', 'c', 'c', 'c'];
-        var frequencyMap = list.frequencies;
+        var frequencyMap = list.countFrequency();
         expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
       });
 
       test('should handle empty List', () {
         var list = [];
-        var frequencyMap = list.frequencies;
+        var frequencyMap = list.countFrequency();
         expect(frequencyMap, {});
       });
 
       test('should handle single element List', () {
         var list = [42];
-        var frequencyMap = list.frequencies;
+        var frequencyMap = list.countFrequency();
         expect(frequencyMap, {42: 1});
       });
 
       test('should return correct frequency map for Set of integers', () {
         // ignore: equal_elements_in_set
         var set = {1, 2, 2, 3, 3, 3};
-        var frequencyMap = set.frequencies;
+        var frequencyMap = set.countFrequency();
         expect(frequencyMap, {1: 1, 2: 1, 3: 1});
       });
 
       test('should return correct frequency map for Set of strings', () {
         // ignore: equal_elements_in_set
         var set = {'a', 'b', 'b', 'c', 'c', 'c'};
-        var frequencyMap = set.frequencies;
+        var frequencyMap = set.countFrequency();
         expect(frequencyMap, {'a': 1, 'b': 1, 'c': 1});
       });
 
       test('should handle empty Set', () {
         var set = <int>{};
-        var frequencyMap = set.frequencies;
+        var frequencyMap = set.countFrequency();
         expect(frequencyMap, {});
       });
 
       test('should handle single element Set', () {
         var set = {42};
-        var frequencyMap = set.frequencies;
+        var frequencyMap = set.countFrequency();
         expect(frequencyMap, {42: 1});
       });
 
       test('should return correct frequency map for Queue of integers', () {
         var queue = Queue<int>();
         queue.addAll([1, 2, 2, 3, 3, 3]);
-        var frequencyMap = queue.frequencies;
+        var frequencyMap = queue.countFrequency();
         expect(frequencyMap, {1: 1, 2: 2, 3: 3});
       });
 
       test('should return correct frequency map for Queue of strings', () {
         var queue = Queue<String>();
         queue.addAll(['a', 'b', 'b', 'c', 'c', 'c']);
-        var frequencyMap = queue.frequencies;
+        var frequencyMap = queue.countFrequency();
         expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
       });
 
       test('should handle empty Queue', () {
         var queue = Queue<int>();
-        var frequencyMap = queue.frequencies;
+        var frequencyMap = queue.countFrequency();
         expect(frequencyMap, {});
       });
 
       test('should handle single element Queue', () {
         var queue = Queue<int>();
         queue.add(42);
-        var frequencyMap = queue.frequencies;
+        var frequencyMap = queue.countFrequency();
         expect(frequencyMap, {42: 1});
       });
     });

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1353,81 +1353,81 @@ void main() {
         expect(l3.toList(), [4, 5]);
       });
     });
-    group('FrequencyCounter tests', () {
+    group('get frequencies tests', () {
       test('should return correct frequency map for List of integers', () {
         var list = [1, 2, 2, 3, 3, 3];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {1: 1, 2: 2, 3: 3});
       });
 
       test('should return correct frequency map for List of strings', () {
         var list = ['a', 'b', 'b', 'c', 'c', 'c'];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
       });
 
       test('should handle empty List', () {
         var list = [];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {});
       });
 
       test('should handle single element List', () {
         var list = [42];
-        var frequencyMap = list.countFrequency();
+        var frequencyMap = list.frequencies;
         expect(frequencyMap, {42: 1});
       });
 
       test('should return correct frequency map for Set of integers', () {
         // ignore: equal_elements_in_set
         var set = {1, 2, 2, 3, 3, 3};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {1: 1, 2: 1, 3: 1});
       });
 
       test('should return correct frequency map for Set of strings', () {
         // ignore: equal_elements_in_set
         var set = {'a', 'b', 'b', 'c', 'c', 'c'};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {'a': 1, 'b': 1, 'c': 1});
       });
 
       test('should handle empty Set', () {
         var set = <int>{};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {});
       });
 
       test('should handle single element Set', () {
         var set = {42};
-        var frequencyMap = set.countFrequency();
+        var frequencyMap = set.frequencies;
         expect(frequencyMap, {42: 1});
       });
 
       test('should return correct frequency map for Queue of integers', () {
         var queue = Queue<int>();
         queue.addAll([1, 2, 2, 3, 3, 3]);
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {1: 1, 2: 2, 3: 3});
       });
 
       test('should return correct frequency map for Queue of strings', () {
         var queue = Queue<String>();
         queue.addAll(['a', 'b', 'b', 'c', 'c', 'c']);
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {'a': 1, 'b': 2, 'c': 3});
       });
 
       test('should handle empty Queue', () {
         var queue = Queue<int>();
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {});
       });
 
       test('should handle single element Queue', () {
         var queue = Queue<int>();
         queue.add(42);
-        var frequencyMap = queue.countFrequency();
+        var frequencyMap = queue.frequencies;
         expect(frequencyMap, {42: 1});
       });
     });


### PR DESCRIPTION
[yes] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Description:
This Pull Request introduces a new extension getter frequencies for the Iterable class. The countFrequency method returns a map where the keys are the unique elements of the iterable and the values are the counts of those elements. This addition provides an easy and efficient way to count the frequency of elements in any iterable.

Changes:
- Added frequencies getter extension to lib/src/iterable_extensions.dart
- Implemented comprehensive tests for the frequencies getter in test/extensions_test.dart. The tests cover various subclasses of Iterable including List, Set, and Queue.

Relevant Issues:
This PR addresses [Issue dart-lang/core#679](https://github.com/dart-lang/core/issues/679).

Thank you!