### PR TITLE
Add .toMap extensions for tuples/pairs and key+value records

### DIFF
--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -914,6 +914,18 @@ extension IterableIterableExtension<T> on Iterable<Iterable<T>> {
       };
 }
 
+/// Extensions that apply to iterables of tuples/pairs (records with two unnamed elements).
+extension IterableTupleExtension<T1, T2> on Iterable<(T1, T2)> {
+  /// Returns a map from the first element of each tuple to the second element.
+  Map<T1, T2> get toMap => {for (final element in this) element.$1: element.$2};
+}
+
+extension IterableKeyValueExtension<T1, T2> on Iterable<({T1 key, T2 value})> {
+  /// Returns a map from the key of each element to the value of that element.
+  Map<T1, T2> get toMap =>
+      {for (final element in this) element.key: element.value};
+}
+
 /// Extensions that apply to iterables of [Comparable] elements.
 ///
 /// These operations can assume that the elements have a natural ordering,


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Since records were introduced in Dart, they have become a much simpler way of representing a list of keys and values than `MapEntry`s.

This change adds an easy way for users to turn them into maps.