### PR TITLE
Implement `firstWhereType` and `firstWhereTypeOrNull`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.20.0-wip
+
+- Adds `firstWhereType` to `IterableExtension`.
+- Adds `firstWhereTypeOrNull` to `IterableExtension`.
+
 ## 1.19.0
 
 - Adds `shuffled` to `IterableExtension`.

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -250,6 +250,28 @@ extension IterableExtension<T> on Iterable<T> {
     return result;
   }
 
+  /// The first element with type [T].
+  ///
+  /// If no element with type [T] is found, the result of invoking the [orElse]
+  /// function is returned. If [orElse] is omitted, it defaults to throwing a
+  /// [StateError]. Stops iterating on the first matching element.
+  R firstWhereType<R>([R Function()? orElse]) {
+    for (var element in this) {
+      if (element is R) return element;
+    }
+
+    if (orElse != null) {
+      return orElse();
+    } else {
+      throw StateError('No element with type $R');
+    }
+  }
+
+  /// The first element with type [T], or `null` if there are none.
+  R? firstWhereTypeOrNull<R>() {
+    return firstWhereType<R?>(() => null);
+  }
+
   /// The first element satisfying [test], or `null` if there are none.
   T? firstWhereOrNull(bool Function(T element) test) {
     for (var element in this) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.19.0
+version: 1.20.0-wip
 description: >-
   Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/collection

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -387,6 +387,46 @@ void main() {
               'x:0:1:1:3:2:9');
         });
       });
+      group('.firstWhereType', () {
+        test('empty', () {
+          expect(() => iterable([]).firstWhereType<String>(), throwsStateError);
+        });
+        test('none', () {
+          expect(() => iterable([1, 3, 7]).firstWhereType<String>(), throwsStateError);
+        });
+        test('single', () {
+          expect(iterable([0, '1', 2]).firstWhereType<String>(), '1');
+        });
+        test('first of multiple', () {
+          expect(iterable([0, '1', '2']).firstWhereType<String>(), '1');
+        });
+        test('empty with orElse', () {
+          expect(iterable([]).firstWhereType<String>(() => ''), '');
+        });
+        test('none with orElse', () {
+          expect(iterable([1, 3, 7]).firstWhereType<String>(() => ''), '');
+        });
+        test('single with orElse', () {
+          expect(iterable([0, '1', 2]).firstWhereType<String>(() => ''), '1');
+        });
+        test('first of multiple with orElse', () {
+          expect(iterable([0, '1', '3']).firstWhereType<String>(() => ''), '1');
+        });
+      });
+      group('.firstWhereTypeOrNull', () {
+        test('empty', () {
+          expect(iterable([]).firstWhereTypeOrNull<String>(), null);
+        });
+        test('none', () {
+          expect(iterable([1, 3, 7]).firstWhereTypeOrNull<String>(), null);
+        });
+        test('single', () {
+          expect(iterable([0, '1', 2]).firstWhereTypeOrNull<String>(), '1');
+        });
+        test('first of multiple', () {
+          expect(iterable([0, '1', '3']).firstWhereTypeOrNull<String>(), '1');
+        });
+      });
       group('.firstWhereOrNull', () {
         test('empty', () {
           expect(iterable([]).firstWhereOrNull(unreachable), null);

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -392,7 +392,10 @@ void main() {
           expect(() => iterable([]).firstWhereType<String>(), throwsStateError);
         });
         test('none', () {
-          expect(() => iterable([1, 3, 7]).firstWhereType<String>(), throwsStateError);
+          expect(
+            () => iterable([1, 3, 7]).firstWhereType<String>(),
+            throwsStateError,
+          );
         });
         test('single', () {
           expect(iterable([0, '1', 2]).firstWhereType<String>(), '1');


### PR DESCRIPTION
Adds `firstWhereType` and `firstWhereTypeOrNull`.
Fixes #352.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
